### PR TITLE
lite: use flags instead of parsing args

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,11 @@ interested in building their own relayer can come for working examples.
   * [x] `list [chain-id]` - list the keys associated with a given chain
   * [x] `restore [chain-id] [name] [mnemonic]` - Restore a key to a chain's keychain with a name and mnemonic
   * [x] `show [chain-id] [name]` - Show details for a key from a given chain
-- [ ] `lite` - @melekes working on ensuring commands work as intended
-  * [ ] `init [chain-id] [header-hash] [height]` - Initialize from a header hash and a height
-  * [x] `init-force [chain-id]` - Initialize from provider configured for `chain-id`
+- [x] `lite` - @melekes working on ensuring commands work as intended
+  * [x] `init [chain-id] (flags)` - Initialize from a header hash and a height
   * [x] `header [chain-id] [height]` - Returns a header at height from the database
-  * [x] `latest-height [chain-id]` - Returns the latest height from the database
-  * [ ] `update [chain-id] [header-hash] [height]` - Updates lite client to given header
-  * [x] `update-force [chain-id]` - Updates to latest header from configured provider
-  * [ ] `reset [chain-id]` - Deletes on disk lite client forcing re-initialization
+  * [x] `update [chain-id] [header-hash] [height]` - Updates lite client to given header
+  * [x] `delete [chain-id]` - Deletes on disk lite client forcing re-initialization
 - [ ] `query` - Some implementations working/complete others just stubbs. All queries from the `relayer` return proofs!
   * [x] `client [chain-id] [client-id]` - Query details for an individual client
   * [x] `clients [chain-id]` - Query the list of clients on a given chain

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -74,7 +74,7 @@ func setChains(c *Config, home string) error {
 		for _, cp := range i.Counterparties {
 			cps = append(cps, relayer.NewCounterparty(cp.ChainID, cp.ClientID))
 		}
-		homeDir := path.Join(home, i.ChainID)
+		homeDir := path.Join(home, liteDir)
 		chain, err := relayer.NewChain(i.Key, i.ChainID, i.RPCAddr, i.AccountPrefix, cps, i.Gas, i.GasAdjustment,
 			i.GasPrices, i.DefaultDenom, i.Memo, homePath, c.Global.LiteCacheSize, i.TrustingPeriod,
 			homeDir)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -75,9 +75,10 @@ func setChains(c *Config, home string) error {
 			cps = append(cps, relayer.NewCounterparty(cp.ChainID, cp.ClientID))
 		}
 		homeDir := path.Join(home, liteDir)
-		chain, err := relayer.NewChain(i.Key, i.ChainID, i.RPCAddr, i.AccountPrefix, cps, i.Gas, i.GasAdjustment,
-			i.GasPrices, i.DefaultDenom, i.Memo, homePath, c.Global.LiteCacheSize, i.TrustingPeriod,
-			homeDir)
+		chain, err := relayer.NewChain(i.Key, i.ChainID, i.RPCAddr,
+			i.AccountPrefix, cps, i.Gas, i.GasAdjustment, i.GasPrices,
+			i.DefaultDenom, i.Memo, homePath, c.Global.LiteCacheSize,
+			i.TrustingPeriod, homeDir)
 		if err != nil {
 			return err
 		}

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -24,12 +24,12 @@ import (
 )
 
 func init() {
-	keysCmd.AddCommand(keysAddCmd)
-	keysCmd.AddCommand(keysRestoreCmd)
-	keysCmd.AddCommand(keysDeleteCmd)
-	keysCmd.AddCommand(keysListCmd)
-	keysCmd.AddCommand(keysShowCmd)
-	keysCmd.AddCommand(keysExportCmd)
+	keysCmd.AddCommand(keysAddCmd())
+	keysCmd.AddCommand(keysRestoreCmd())
+	keysCmd.AddCommand(keysDeleteCmd())
+	keysCmd.AddCommand(keysListCmd())
+	keysCmd.AddCommand(keysShowCmd())
+	keysCmd.AddCommand(keysExportCmd())
 }
 
 // keysCmd represents the keys command
@@ -39,200 +39,223 @@ var keysCmd = &cobra.Command{
 }
 
 // keysAddCmd respresents the `keys add` command
-var keysAddCmd = &cobra.Command{
-	Use:   "add [chain-id] [name]",
-	Short: "adds a key to the keychain associated with a particular chain",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		chainID := args[0]
-		keyName := args[1]
+func keysAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add [chain-id] [name]",
+		Short: "adds a key to the keychain associated with a particular chain",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
+			keyName := args[1]
 
-		if !config.c.Exists(chainID) {
-			return fmt.Errorf("chain with ID %s is not configured", chainID)
-		}
+			if !config.c.Exists(chainID) {
+				return fmt.Errorf("chain with ID %s is not configured", chainID)
+			}
 
-		chain, err := config.c.GetChain(chainID)
-		if err != nil {
-			return err
-		}
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
 
-		mnemonic, err := createMnemonic()
-		if err != nil {
-			return err
-		}
+			mnemonic, err := createMnemonic()
+			if err != nil {
+				return err
+			}
 
-		if keyExists(chain.Keybase, keyName) {
-			return fmt.Errorf("a key with name %s already exists", keyName)
-		}
+			if keyExists(chain.Keybase, keyName) {
+				return fmt.Errorf("a key with name %s already exists", keyName)
+			}
 
-		info, err := chain.Keybase.CreateAccount(keyName, mnemonic, "", "", keys.CreateHDPath(0, 0).String(), keys.Secp256k1)
-		if err != nil {
-			return err
-		}
+			info, err := chain.Keybase.CreateAccount(keyName, mnemonic, "", "", keys.CreateHDPath(0, 0).String(), keys.Secp256k1)
+			if err != nil {
+				return err
+			}
 
-		fmt.Println("seed:   ", mnemonic)
-		fmt.Println("address:", info.GetAddress().String())
-		return nil
-	},
+			fmt.Println("seed:   ", mnemonic)
+			fmt.Println("address:", info.GetAddress().String())
+			return nil
+		},
+	}
+	return cmd
 }
 
 // keysRestoreCmd respresents the `keys add` command
-var keysRestoreCmd = &cobra.Command{
-	Use:   "restore [chain-id] [name] [mnemonic]",
-	Short: "restores a mnemonic to the keychain associated with a particular chain",
-	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		chainID := args[0]
-		keyName := args[1]
-		mnemonic := args[2]
+func keysRestoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore [chain-id] [name] [mnemonic]",
+		Short: "restores a mnemonic to the keychain associated with a particular chain",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
+			keyName := args[1]
+			mnemonic := args[2]
 
-		if !config.c.Exists(chainID) {
-			return fmt.Errorf("chain with ID %s is not configured", chainID)
-		}
+			if !config.c.Exists(chainID) {
+				return fmt.Errorf("chain with ID %s is not configured", chainID)
+			}
 
-		chain, err := config.c.GetChain(chainID)
-		if err != nil {
-			return err
-		}
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
 
-		if keyExists(chain.Keybase, keyName) {
-			return fmt.Errorf("a key with name %s already exists", keyName)
-		}
+			if keyExists(chain.Keybase, keyName) {
+				return fmt.Errorf("a key with name %s already exists", keyName)
+			}
 
-		info, err := chain.Keybase.CreateAccount(keyName, mnemonic, "", "", keys.CreateHDPath(0, 0).String(), keys.Secp256k1)
-		if err != nil {
-			return err
-		}
+			info, err := chain.Keybase.CreateAccount(keyName, mnemonic, "", "", keys.CreateHDPath(0, 0).String(), keys.Secp256k1)
+			if err != nil {
+				return err
+			}
 
-		fmt.Println(info.GetAddress().String())
-		return nil
-	},
+			fmt.Println(info.GetAddress().String())
+			return nil
+		},
+	}
+
+	return cmd
 }
 
 // keysDeleteCmd respresents the `keys delete` command
-var keysDeleteCmd = &cobra.Command{
-	Use:   "delete [chain-id] [name]",
-	Short: "deletes a key from the keychain associated with a particular chain",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		chainID := args[0]
-		keyName := args[1]
+func keysDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [chain-id] [name]",
+		Short: "deletes a key from the keychain associated with a particular chain",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
+			keyName := args[1]
 
-		if !config.c.Exists(chainID) {
-			return fmt.Errorf("chain with ID %s is not configured", chainID)
-		}
+			if !config.c.Exists(chainID) {
+				return fmt.Errorf("chain with ID %s is not configured", chainID)
+			}
 
-		chain, err := config.c.GetChain(chainID)
-		if err != nil {
-			return err
-		}
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
 
-		if !keyExists(chain.Keybase, keyName) {
-			return fmt.Errorf("a key with name %s doesn't exist", keyName)
-		}
+			if !keyExists(chain.Keybase, keyName) {
+				return fmt.Errorf("a key with name %s doesn't exist", keyName)
+			}
 
-		err = chain.Keybase.Delete(keyName, "", true)
-		if err != nil {
-			panic(err)
-		}
+			err = chain.Keybase.Delete(keyName, "", true)
+			if err != nil {
+				panic(err)
+			}
 
-		fmt.Printf("key %s deleted\n", keyName)
-		return nil
-	},
+			fmt.Printf("key %s deleted\n", keyName)
+			return nil
+		},
+	}
+
+	return cmd
 }
 
 // keysListCmd respresents the `keys list` command
-var keysListCmd = &cobra.Command{
-	Use:   "list [chain-id]",
-	Short: "lists keys from the keychain associated with a particular chain",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		chainID := args[0]
+func keysListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list [chain-id]",
+		Short: "lists keys from the keychain associated with a particular chain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
 
-		if !config.c.Exists(chainID) {
-			return fmt.Errorf("chain with ID %s is not configured", chainID)
-		}
+			if !config.c.Exists(chainID) {
+				return fmt.Errorf("chain with ID %s is not configured", chainID)
+			}
 
-		chain, err := config.c.GetChain(chainID)
-		if err != nil {
-			return err
-		}
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
 
-		info, err := chain.Keybase.List()
-		if err != nil {
-			return err
-		}
+			info, err := chain.Keybase.List()
+			if err != nil {
+				return err
+			}
 
-		for _, k := range info {
-			fmt.Println(k.GetName(), "->", k.GetAddress().String())
-		}
+			for _, k := range info {
+				fmt.Println(k.GetName(), "->", k.GetAddress().String())
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
+
+	return cmd
 }
 
 // keysShowCmd respresents the `keys show` command
-var keysShowCmd = &cobra.Command{
-	Use:   "show [chain-id] [name]",
-	Short: "shows a key from the keychain associated with a particular chain",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		chainID := args[0]
-		keyName := args[1]
+func keysShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show [chain-id] [name]",
+		Short: "shows a key from the keychain associated with a particular chain",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
+			keyName := args[1]
 
-		if !config.c.Exists(chainID) {
-			return fmt.Errorf("chain with ID %s is not configured", chainID)
-		}
+			if !config.c.Exists(chainID) {
+				return fmt.Errorf("chain with ID %s is not configured", chainID)
+			}
 
-		chain, err := config.c.GetChain(chainID)
-		if err != nil {
-			return err
-		}
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
 
-		if !keyExists(chain.Keybase, keyName) {
-			return fmt.Errorf("a key with name %s doesn't exist", keyName)
-		}
+			if !keyExists(chain.Keybase, keyName) {
+				return fmt.Errorf("a key with name %s doesn't exist", keyName)
+			}
 
-		info, err := chain.Keybase.Get(keyName)
-		if err != nil {
-			return err
-		}
+			info, err := chain.Keybase.Get(keyName)
+			if err != nil {
+				return err
+			}
 
-		fmt.Println(info.GetAddress().String())
-		return nil
-	},
+			fmt.Println(info.GetAddress().String())
+			return nil
+		},
+	}
+
+	return cmd
 }
 
 // keysExportCmd respresents the `keys export` command
-var keysExportCmd = &cobra.Command{
-	Use:   "export [chain-id] [name]",
-	Short: "exports a privkey from the keychain associated with a particular chain",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		chainID := args[0]
-		keyName := args[1]
+func keysExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export [chain-id] [name]",
+		Short: "exports a privkey from the keychain associated with a particular chain",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
+			keyName := args[1]
 
-		if !config.c.Exists(chainID) {
-			return fmt.Errorf("chain with ID %s is not configured", chainID)
-		}
+			if !config.c.Exists(chainID) {
+				return fmt.Errorf("chain with ID %s is not configured", chainID)
+			}
 
-		chain, err := config.c.GetChain(chainID)
-		if err != nil {
-			return err
-		}
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
 
-		if !keyExists(chain.Keybase, keyName) {
-			return fmt.Errorf("a key with name %s doesn't exist", keyName)
-		}
+			if !keyExists(chain.Keybase, keyName) {
+				return fmt.Errorf("a key with name %s doesn't exist", keyName)
+			}
 
-		info, err := chain.Keybase.ExportPrivKey(keyName, "", "")
-		if err != nil {
-			return err
-		}
+			info, err := chain.Keybase.ExportPrivKey(keyName, "", "")
+			if err != nil {
+				return err
+			}
 
-		fmt.Println(info)
-		return nil
-	},
+			fmt.Println(info)
+			return nil
+		},
+	}
+
+	return cmd
 }
 
 // returns true if there is a specified key in the keybase

--- a/cmd/lite.go
+++ b/cmd/lite.go
@@ -57,9 +57,10 @@ var liteCmd = &cobra.Command{
 }
 
 func init() {
-	liteCmd.AddCommand(headerCmd())
+	liteCmd.AddCommand(liteHeaderCmd())
 	liteCmd.AddCommand(initLiteCmd())
 	liteCmd.AddCommand(updateLiteCmd())
+	liteCmd.AddCommand(deleteLiteCmd())
 }
 
 func initLiteCmd() *cobra.Command {
@@ -220,7 +221,7 @@ func updateLiteCmd() *cobra.Command {
 	return cmd
 }
 
-func headerCmd() *cobra.Command {
+func liteHeaderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "header [chain-id] [height]",
 		Short: "Get header from the database. 0 returns last trusted header and " +
@@ -272,6 +273,29 @@ func headerCmd() *cobra.Command {
 			}
 
 			fmt.Println(string(out))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func deleteLiteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [chain-id]",
+		Short: "wipe the lite client database, forcing re-initialzation on the next run",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chainID := args[0]
+			chain, err := config.c.GetChain(chainID)
+			if err != nil {
+				return err
+			}
+
+			err = chain.DeleteLiteDB()
+			if err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}

--- a/cmd/lite.go
+++ b/cmd/lite.go
@@ -27,22 +27,14 @@ import (
 	tmclient "github.com/cosmos/cosmos-sdk/x/ibc/07-tendermint"
 	"github.com/cosmos/relayer/relayer"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	lite "github.com/tendermint/tendermint/lite2"
 )
 
 var (
-	flagHeight          = "height"
-	heightDesc          = "Trusted header's height"
-	heightDefault int64 = -1
-
-	flagHash    = "hash"
-	hashDesc    = "Trusted header's hash"
-	hashShort   = "x"
-	hashDefault = []byte{}
-
-	flagURL  = "url"
-	urlDesc  = "Optional URL to fetch trusted-hash and trusted-height"
-	urlShort = "u"
+	flagHeight = "height"
+	flagHash   = "hash"
+	flagURL    = "url"
 
 	flagForce    = "force"
 	forceDesc    = "Option to skip confirmation prompt for trusting hash & height from configured url"
@@ -135,12 +127,10 @@ func initLiteCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64(flagHeight, heightDefault, heightDesc)
-	cmd.Flags().BytesHexP(flagHash, hashShort, hashDefault, hashDesc)
-	cmd.Flags().StringP(flagURL, urlShort, "", urlDesc)
-	cmd.Flags().BoolP(flagForce, forceShort, false, forceDesc)
+	cmd.Flags().BoolP(flagForce, "f", false, "Option to skip confirmation prompt for trusting hash & height from configured url")
+	viper.BindPFlag(flagForce, cmd.Flags().Lookup(flagForce))
 
-	return cmd
+	return liteFlags(cmd)
 }
 
 func updateLiteCmd() *cobra.Command {
@@ -214,11 +204,7 @@ func updateLiteCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64(flagHeight, heightDefault, heightDesc)
-	cmd.Flags().BytesHexP(flagHash, hashShort, hashDefault, hashDesc)
-	cmd.Flags().StringP(flagURL, urlShort, "", urlDesc)
-
-	return cmd
+	return liteFlags(cmd)
 }
 
 func liteHeaderCmd() *cobra.Command {
@@ -328,6 +314,16 @@ func queryTrustOptions(url string) (out lite.TrustOptions, err error) {
 	}
 
 	return
+}
+
+func liteFlags(cmd *cobra.Command) *cobra.Command {
+	cmd.Flags().Int64(flagHeight, -1, "Trusted header's height")
+	cmd.Flags().BytesHexP(flagHash, "x", []byte{}, "Trusted header's hash")
+	cmd.Flags().StringP(flagURL, "u", "", "Optional URL to fetch trusted-hash and trusted-height")
+	viper.BindPFlag(flagHeight, cmd.Flags().Lookup(flagHeight))
+	viper.BindPFlag(flagHash, cmd.Flags().Lookup(flagHash))
+	viper.BindPFlag(flagURL, cmd.Flags().Lookup(flagURL))
+	return cmd
 }
 
 func wrapQueryTrustOptsErr(err error) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,6 @@ import (
 const (
 	homeFlag = "home"
 	cfgDir   = "config"
-	keyDir   = "keys"
 	liteDir  = "lite"
 	cfgFile  = "config.yaml"
 	homeDisc = "set home directory"

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -23,10 +23,10 @@ import (
 )
 
 func init() {
-	transactionCmd.AddCommand(createClientCmd)
-	transactionCmd.AddCommand(createClientsCmd)
-	transactionCmd.AddCommand(createConnectionCmd)
-	transactionCmd.AddCommand(createChannelCmd)
+	transactionCmd.AddCommand(createClientCmd())
+	transactionCmd.AddCommand(createClientsCmd())
+	transactionCmd.AddCommand(createConnectionCmd())
+	transactionCmd.AddCommand(createChannelCmd())
 }
 
 // transactionCmd represents the tx command
@@ -36,169 +36,184 @@ var transactionCmd = &cobra.Command{
 	Short:   "IBC Transaction Commands, UNDER CONSTRUCTION",
 }
 
-var createClientCmd = &cobra.Command{
-	Use:   "client [src-chain-id] [dst-chain-id] [client-id]",
-	Short: "create a client for dst-chain on src-chain",
-	Args:  cobra.ExactArgs(3),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		srcChain, err := config.c.GetChain(args[0])
-		if err != nil {
-			return err
-		}
+func createClientCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "client [src-chain-id] [dst-chain-id] [client-id]",
+		Short: "create a client for dst-chain on src-chain",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			srcChain, err := config.c.GetChain(args[0])
+			if err != nil {
+				return err
+			}
 
-		dstChain, err := config.c.GetChain(args[1])
-		if err != nil {
-			return err
-		}
+			dstChain, err := config.c.GetChain(args[1])
+			if err != nil {
+				return err
+			}
 
-		err = srcChain.UpdateLiteDBToLatestHeader()
-		if err != nil {
-			return err
-		}
+			err = srcChain.UpdateLiteDBToLatestHeader()
+			if err != nil {
+				return err
+			}
 
-		err = dstChain.UpdateLiteDBToLatestHeader()
-		if err != nil {
-			return err
-		}
+			err = dstChain.UpdateLiteDBToLatestHeader()
+			if err != nil {
+				return err
+			}
 
-		dstHeight, err := dstChain.QueryLatestHeight()
-		if err != nil {
-			return err
-		}
+			dstHeight, err := dstChain.QueryLatestHeight()
+			if err != nil {
+				return err
+			}
 
-		srcAddr, err := srcChain.GetAddress()
-		if err != nil {
-			return err
-		}
+			srcAddr, err := srcChain.GetAddress()
+			if err != nil {
+				return err
+			}
 
-		msgCreateClient, err := srcChain.CreateClient(dstChain, dstHeight, srcAddr)
-		if err != nil {
-			return err
-		}
+			msgCreateClient, err := srcChain.CreateClient(dstChain, dstHeight, srcAddr)
+			if err != nil {
+				return err
+			}
 
-		res, err := srcChain.SendMsg(msgCreateClient)
-		if err != nil {
-			return err
-		}
+			res, err := srcChain.SendMsg(msgCreateClient)
+			if err != nil {
+				return err
+			}
 
-		fmt.Println(res)
-		return nil
-	},
+			fmt.Println(res)
+			return nil
+		},
+	}
+
+	return cmd
 }
 
-var createClientsCmd = &cobra.Command{
-	Use:   "clients [src-chain-id] [dst-chain-id] [src-client-id] [dst-client-id]",
-	Short: "create a clients for dst-chain on src-chain and src-chain on dst-chain",
-	Args:  cobra.ExactArgs(4),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		srcChain, err := config.c.GetChain(args[0])
-		if err != nil {
-			return err
-		}
+func createClientsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clients [src-chain-id] [dst-chain-id] [src-client-id] [dst-client-id]",
+		Short: "create a clients for dst-chain on src-chain and src-chain on dst-chain",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			srcChain, err := config.c.GetChain(args[0])
+			if err != nil {
+				return err
+			}
 
-		dstChain, err := config.c.GetChain(args[1])
-		if err != nil {
-			return err
-		}
+			dstChain, err := config.c.GetChain(args[1])
+			if err != nil {
+				return err
+			}
 
-		dstHeight, err := dstChain.QueryLatestHeight()
-		if err != nil {
-			return err
-		}
+			dstHeight, err := dstChain.QueryLatestHeight()
+			if err != nil {
+				return err
+			}
 
-		srcHeight, err := srcChain.QueryLatestHeight()
-		if err != nil {
-			return err
-		}
+			srcHeight, err := srcChain.QueryLatestHeight()
+			if err != nil {
+				return err
+			}
 
-		srcAddr, err := srcChain.GetAddress()
-		if err != nil {
-			return err
-		}
+			srcAddr, err := srcChain.GetAddress()
+			if err != nil {
+				return err
+			}
 
-		dstAddr, err := dstChain.GetAddress()
-		if err != nil {
-			return err
-		}
+			dstAddr, err := dstChain.GetAddress()
+			if err != nil {
+				return err
+			}
 
-		srcCreateClient, err := srcChain.CreateClient(dstChain, dstHeight, srcAddr)
-		if err != nil {
-			return err
-		}
+			srcCreateClient, err := srcChain.CreateClient(dstChain, dstHeight, srcAddr)
+			if err != nil {
+				return err
+			}
 
-		res, err := srcChain.SendMsg(srcCreateClient)
-		if err != nil {
-			return err
-		}
-		fmt.Println(res)
+			res, err := srcChain.SendMsg(srcCreateClient)
+			if err != nil {
+				return err
+			}
+			fmt.Println(res)
 
-		dstCreateClient, err := dstChain.CreateClient(srcChain, srcHeight, dstAddr)
-		if err != nil {
-			return err
-		}
+			dstCreateClient, err := dstChain.CreateClient(srcChain, srcHeight, dstAddr)
+			if err != nil {
+				return err
+			}
 
-		res, err = dstChain.SendMsg(dstCreateClient)
-		if err != nil {
-			return err
-		}
+			res, err = dstChain.SendMsg(dstCreateClient)
+			if err != nil {
+				return err
+			}
 
-		fmt.Println(res)
-		return nil
-	},
+			fmt.Println(res)
+			return nil
+		},
+	}
+	return cmd
 }
 
-var createConnectionCmd = &cobra.Command{
-	Use:   "connection [src-chain-id] [dst-chain-id] [src-client-id] [dst-client-id] [src-connection-id], [dst-connection-id]",
-	Short: "create a connection between chains, passing in identifiers",
-	Args:  cobra.ExactArgs(6),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		timeout := 5 * time.Second
+func createConnectionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "connection [src-chain-id] [dst-chain-id] [src-client-id] [dst-client-id] [src-connection-id], [dst-connection-id]",
+		Short: "create a connection between chains, passing in identifiers",
+		Args:  cobra.ExactArgs(6),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			timeout := 5 * time.Second
 
-		srcChain, err := config.c.GetChain(args[0])
-		if err != nil {
-			return err
-		}
+			srcChain, err := config.c.GetChain(args[0])
+			if err != nil {
+				return err
+			}
 
-		dstChain, err := config.c.GetChain(args[1])
-		if err != nil {
-			return err
-		}
+			dstChain, err := config.c.GetChain(args[1])
+			if err != nil {
+				return err
+			}
 
-		// TODO: validate identifiers ICS24
+			// TODO: validate identifiers ICS24
 
-		err = srcChain.CreateConnection(dstChain, args[2], args[3], args[4], args[5], timeout)
-		if err != nil {
-			return err
-		}
+			err = srcChain.CreateConnection(dstChain, args[2], args[3], args[4], args[5], timeout)
+			if err != nil {
+				return err
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
+
+	return cmd
 }
 
-var createChannelCmd = &cobra.Command{
-	Use:   "channel [src-chain-id] [dst-chain-id] [src-connection-id] [dst-connection-id] [src-channel-id] [dst-channel-id] [src-port-id] [dst-port-id]",
-	Short: "",
-	Args:  cobra.ExactArgs(8),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		timeout := 5 * time.Second
+func createChannelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "channel [src-chain-id] [dst-chain-id] [src-connection-id] [dst-connection-id] [src-channel-id] [dst-channel-id] [src-port-id] [dst-port-id]",
+		Short: "",
+		Args:  cobra.ExactArgs(8),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			timeout := 5 * time.Second
 
-		srcChain, err := config.c.GetChain(args[0])
-		if err != nil {
-			return err
-		}
+			srcChain, err := config.c.GetChain(args[0])
+			if err != nil {
+				return err
+			}
 
-		dstChain, err := config.c.GetChain(args[1])
-		if err != nil {
-			return err
-		}
+			dstChain, err := config.c.GetChain(args[1])
+			if err != nil {
+				return err
+			}
 
-		// TODO: validate identifiers ICS24
+			// TODO: validate identifiers ICS24
 
-		err = srcChain.CreateChannel(dstChain, args[2], args[3], args[4], args[5], args[6], args[7], timeout)
-		if err != nil {
-			return err
-		}
+			err = srcChain.CreateChannel(dstChain, args[2], args[3], args[4], args[5], args[6], args[7], timeout)
+			if err != nil {
+				return err
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
+
+	return cmd
 }

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -23,7 +23,7 @@ func NewChain(key, chainID, rpcAddr, accPrefix string,
 	gasPrices sdk.DecCoins, defaultDenom, memo, homePath string,
 	liteCacheSize int, trustingPeriod string, dir string,
 ) (*Chain, error) {
-	keybase, err := keys.NewKeyring(chainID, "test", keysDir(homePath, chainID), nil)
+	keybase, err := keys.NewKeyring(chainID, "test", keysDir(homePath), nil)
 	if err != nil {
 		return &Chain{}, err
 	}
@@ -49,7 +49,7 @@ func NewChain(key, chainID, rpcAddr, accPrefix string,
 	return &Chain{
 		Key: key, ChainID: chainID, RPCAddr: rpcAddr, AccountPrefix: accPrefix, Counterparties: counterparties, Gas: gas,
 		GasAdjustment: gasAdj, GasPrices: gasPrices, DefaultDenom: defaultDenom, Memo: memo, Keybase: keybase,
-		Client: client, Cdc: cdc, TrustingPeriod: tp, ChainDir: dir}, nil
+		Client: client, Cdc: cdc, TrustingPeriod: tp, HomePath: homePath}, nil
 }
 
 // Chain represents the necessary data for connecting to and indentifying a chain and its counterparites
@@ -65,12 +65,12 @@ type Chain struct {
 	DefaultDenom   string         `yaml:"default-denom,omitempty"`
 	Memo           string         `yaml:"memo,omitempty"`
 	TrustingPeriod time.Duration  `yaml:"trusting-period"`
+	HomePath       string
 
-	Keybase  keys.Keybase
-	Client   *rpcclient.HTTP
-	Cdc      *codec.Codec
-	ChainDir string
-	logger   log.Logger
+	Keybase keys.Keybase
+	Client  *rpcclient.HTTP
+	Cdc     *codec.Codec
+	logger  log.Logger
 }
 
 // Chains is a collection of Chain
@@ -97,8 +97,12 @@ func (c Chains) GetChain(chainID string) (*Chain, error) {
 }
 
 // KeysDir returns the path to the keys for this chain
-func keysDir(home, chainID string) string {
-	return path.Join(home, "keys", chainID)
+func keysDir(home string) string {
+	return path.Join(home, "keys")
+}
+
+func liteDir(home string) string {
+	return path.Join(home, "lite")
 }
 
 // GetAddress returns the sdk.AccAddress associated with the configred key

--- a/relayer/verifier.go
+++ b/relayer/verifier.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"time"
 
 	tmclient "github.com/cosmos/cosmos-sdk/x/ibc/07-tendermint"
@@ -125,7 +126,7 @@ func (c *Chain) TrustNodeInitClient(db *dbm.GoLevelDB) (*lite.Client, error) {
 // NewLiteDB returns a new instance of the liteclient database connection
 // CONTRACT: must close the database connection when done with it (defer df())
 func (c *Chain) NewLiteDB() (db *dbm.GoLevelDB, df func(), err error) {
-	db, err = dbm.NewGoLevelDB(c.ChainID, c.ChainDir)
+	db, err = dbm.NewGoLevelDB(c.ChainID, liteDir(c.HomePath))
 	df = func() {
 		err := db.Close()
 		if err != nil {
@@ -136,6 +137,11 @@ func (c *Chain) NewLiteDB() (db *dbm.GoLevelDB, df func(), err error) {
 		return nil, nil, fmt.Errorf("can't open lite client database: %w", err)
 	}
 	return
+}
+
+// DeleteLiteDB removes the lite client database on disk, forcing re-initialization
+func (c *Chain) DeleteLiteDB() error {
+	return os.RemoveAll(filepath.Join(liteDir(c.HomePath), fmt.Sprintf("%s.db", c.ChainID)))
 }
 
 // TrustOptions returns lite.TrustOptions given a height and hash

--- a/relayer/verifier.go
+++ b/relayer/verifier.go
@@ -132,6 +132,9 @@ func (c *Chain) NewLiteDB() (db *dbm.GoLevelDB, df func(), err error) {
 			panic(err)
 		}
 	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't open lite client database: %w", err)
+	}
 	return
 }
 


### PR DESCRIPTION
also, remove init-force and update-force: seem redundant to me. feel
free to revert.

see my notes on UpdateLiteDBToLatestHeader and usage of --url and
--force flags, which are not currently used at all.