### PR TITLE
Continue refactor to improve errors and logging

### DIFF
--- a/ci-chains.sh
+++ b/ci-chains.sh
@@ -63,7 +63,7 @@ $RELAYER --home $RLY_CONF lite init $c0 -f
 $RELAYER --home $RLY_CONF lite init $c1 -f
 
 echo "Create clients"
-$RELAYER --home $RLY_CONF tx clients $c0 $c1
+$RELAYER --home $RLY_CONF tx clients -d $c0 $c1
 
 echo "Query headers"
 $RELAYER --home $RLY_CONF q header $c0   
@@ -78,7 +78,7 @@ $RELAYER --home $RLY_CONF q clients $c0
 $RELAYER --home $RLY_CONF q clients $c1
 
 echo "Creating connection..."
-$RELAYER --home $RLY_CONF tx connection $c0 $c1
+$RELAYER --home $RLY_CONF tx connection -d $c0 $c1
 
 echo "Creating channel..."
-$RELAYER --home $RLY_CONF tx channel $c0 $c1
+$RELAYER --home $RLY_CONF tx channel -d $c0 $c1

--- a/ci-chains.sh
+++ b/ci-chains.sh
@@ -18,7 +18,7 @@ echo "Generating relayer configuration..."
 $RELAYER --home $RLY_CONF config init
 $RELAYER --home $RLY_CONF chains add -f demo/ibc0.json
 $RELAYER --home $RLY_CONF chains add -f demo/ibc1.json
-$RELAYER --home $RLY_CONF paths add ibc0 ibc1 -f demo/path.json
+$RELAYER --home $RLY_CONF paths add ibc0 ibc1 demopath -f demo/path.json
 
 echo "Generating gaia configurations..."
 cd $GAIA_CONF && mkdir ibc-testnets && cd ibc-testnets

--- a/ci-chains.sh
+++ b/ci-chains.sh
@@ -14,10 +14,11 @@ killall gaiad
 
 set -e
 
-echo "Generating relayer configurations..."
-mkdir -p $RLY_CONF/config
-echo "cp $(pwd)/two-chains.yaml $RLY_CONF/config/config.yaml"
-cp $(pwd)/two-chains.yaml $RLY_CONF/config/config.yaml
+echo "Generating relayer configuration..."
+$RELAYER --home $RLY_CONF init
+$RELAYER --home $RLY_CONF chains add -f demo/ibc0.json
+$RELAYER --home $RLY_CONF chains add -f demo/ibc1.json
+$RELAYER --home $RLY_CONF paths add ibc0 ibc1 -f demo/path.json
 
 echo "Generating gaia configurations..."
 cd $GAIA_CONF && mkdir ibc-testnets && cd ibc-testnets

--- a/ci-chains.sh
+++ b/ci-chains.sh
@@ -15,7 +15,7 @@ killall gaiad
 set -e
 
 echo "Generating relayer configuration..."
-$RELAYER --home $RLY_CONF init
+$RELAYER --home $RLY_CONF config init
 $RELAYER --home $RLY_CONF chains add -f demo/ibc0.json
 $RELAYER --home $RLY_CONF chains add -f demo/ibc1.json
 $RELAYER --home $RLY_CONF paths add ibc0 ibc1 -f demo/path.json

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -140,7 +140,7 @@ func chainsAddCmd() *cobra.Command {
 				}
 			}
 
-			if err = validateConfig(out, file, debug); err != nil {
+			if err = validateConfig(out); err != nil {
 				return err
 			}
 

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -140,7 +140,7 @@ func chainsAddCmd() *cobra.Command {
 				}
 			}
 
-			if err = validateConfig(out, file); err != nil {
+			if err = validateConfig(out, file, debug); err != nil {
 				return err
 			}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -189,7 +189,7 @@ func (c *Config) DeleteChain(chain string) *Config {
 }
 
 // Called to initialize the relayer.Chain types on Config
-func validateConfig(c *Config, home string) error {
+func validateConfig(c *Config, home string, debug bool) error {
 	var new = &Config{Global: c.Global, Chains: relayer.Chains{}, Paths: c.Paths}
 	to, err := time.ParseDuration(new.Global.Timeout)
 	if err != nil {
@@ -197,7 +197,7 @@ func validateConfig(c *Config, home string) error {
 	}
 
 	for _, i := range c.Chains {
-		chain, err := i.Init(home, appCodec, cdc, to)
+		chain, err := i.Init(home, appCodec, cdc, to, debug)
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func initConfig(cmd *cobra.Command) error {
 			}
 
 			// ensure config has []*relayer.Chain used for all chain operations
-			err = validateConfig(config, home)
+			err = validateConfig(config, home, debug)
 			if err != nil {
 				fmt.Println("Error parsing chain config:", err)
 				os.Exit(1)
@@ -256,7 +256,7 @@ func overWriteConfig(cmd *cobra.Command, cfg *Config) error {
 		viper.SetConfigFile(cfgPath)
 		if err = viper.ReadInConfig(); err == nil {
 			// ensure validateConfig runs properly
-			err = validateConfig(config, home)
+			err = validateConfig(config, home, debug)
 			if err != nil {
 				return err
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -162,7 +162,7 @@ type GlobalConfig struct {
 // newDefaultGlobalConfig returns a global config with defaults set
 func newDefaultGlobalConfig() GlobalConfig {
 	return GlobalConfig{
-		Timeout:       "5s",
+		Timeout:       "10s",
 		LiteCacheSize: 20,
 	}
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -189,7 +189,7 @@ func (c *Config) DeleteChain(chain string) *Config {
 }
 
 // Called to initialize the relayer.Chain types on Config
-func validateConfig(c *Config, home string, debug bool) error {
+func validateConfig(c *Config) error {
 	var new = &Config{Global: c.Global, Chains: relayer.Chains{}, Paths: c.Paths}
 	to, err := time.ParseDuration(new.Global.Timeout)
 	if err != nil {
@@ -197,7 +197,7 @@ func validateConfig(c *Config, home string, debug bool) error {
 	}
 
 	for _, i := range c.Chains {
-		chain, err := i.Init(home, appCodec, cdc, to, debug)
+		chain, err := i.Init(homePath, appCodec, cdc, to, debug)
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func initConfig(cmd *cobra.Command) error {
 			}
 
 			// ensure config has []*relayer.Chain used for all chain operations
-			err = validateConfig(config, home, debug)
+			err = validateConfig(config)
 			if err != nil {
 				fmt.Println("Error parsing chain config:", err)
 				os.Exit(1)
@@ -256,7 +256,7 @@ func overWriteConfig(cmd *cobra.Command, cfg *Config) error {
 		viper.SetConfigFile(cfgPath)
 		if err = viper.ReadInConfig(); err == nil {
 			// ensure validateConfig runs properly
-			err = validateConfig(config, home, debug)
+			err = validateConfig(config)
 			if err != nil {
 				return err
 			}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/relayer/relayer"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
@@ -41,12 +39,6 @@ func paginationFlags(cmd *cobra.Command) *cobra.Command {
 	viper.BindPFlag(flags.FlagPage, cmd.Flags().Lookup(flags.FlagPage))
 	viper.BindPFlag(flags.FlagLimit, cmd.Flags().Lookup(flags.FlagLimit))
 	return cmd
-}
-
-func transactionFlags(cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().BoolP(flagPrintTx, "p", false, "pass flag to print transactions before sending")
-	viper.BindPFlag(flagPrintTx, cmd.Flags().Lookup(flagPrintTx))
-	return outputFlags(cmd)
 }
 
 func outputFlags(cmd *cobra.Command) *cobra.Command {
@@ -108,35 +100,4 @@ func getURL(cmd *cobra.Command) (out string, err error) {
 		}
 	}
 	return
-}
-
-// PrintTxs prints transactions prior to sending if the flag has been passed in
-func PrintTxs(toPrint interface{}, chain *relayer.Chain, cmd *cobra.Command) error {
-	print, err := cmd.Flags().GetBool(flagPrintTx)
-	if err != nil {
-		return err
-	}
-
-	if print {
-		err = queryOutput(toPrint, chain, cmd)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// SendAndPrint sends the transaction with printing options from the CLI
-func SendAndPrint(txs []sdk.Msg, chain *relayer.Chain, cmd *cobra.Command) (err error) {
-	if err = PrintTxs(txs, chain, cmd); err != nil {
-		return err
-	}
-
-	res, err := chain.SendMsgs(txs)
-	if err != nil {
-		return err
-	}
-
-	return queryOutput(res, chain, cmd)
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -243,12 +243,7 @@ func queryClientCmd() *cobra.Command {
 				return err
 			}
 
-			h, err := chain.GetLatestLiteHeight()
-			if err != nil {
-				return err
-			}
-
-			res, err := chain.QueryClientState(h)
+			res, err := chain.QueryClientState()
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -16,6 +16,7 @@ import (
 
 func init() {
 	queryCmd.AddCommand(queryAccountCmd())
+	queryCmd.AddCommand(queryBalanceCmd())
 	queryCmd.AddCommand(queryHeaderCmd())
 	queryCmd.AddCommand(queryNodeStateCmd())
 	queryCmd.AddCommand(queryClientCmd())
@@ -105,7 +106,7 @@ func parseEvents(e string) ([]string, error) {
 func queryAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "account [chain-id]",
-		Short: "Use configured RPC client to fetch the account balance of the relayer account",
+		Short: "Use configured RPC client to fetch the account data of the relayer account",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chain, err := config.Chains.Get(args[0])
@@ -124,6 +125,28 @@ func queryAccountCmd() *cobra.Command {
 			}
 
 			return queryOutput(acc, chain, cmd)
+		},
+	}
+	return outputFlags(cmd)
+}
+
+func queryBalanceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "balance [chain-id]",
+		Short: "Use configured RPC client to fetch the account balance of the relayer account",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chain, err := config.Chains.Get(args[0])
+			if err != nil {
+				return err
+			}
+
+			coins, err := chain.QueryBalance()
+			if err != nil {
+				return err
+			}
+
+			return queryOutput(coins, chain, cmd)
 		},
 	}
 	return outputFlags(cmd)

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -243,7 +243,12 @@ func queryClientCmd() *cobra.Command {
 				return err
 			}
 
-			res, err := chain.QueryClientState()
+			h, err := chain.GetLatestLiteHeight()
+			if err != nil {
+				return err
+			}
+
+			res, err := chain.QueryClientState(h)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -561,3 +561,17 @@ func queryOutput(res interface{}, chain *relayer.Chain, cmd *cobra.Command) erro
 	}
 	return chain.Print(res, text, indent)
 }
+
+func getPrintingFlags(cmd *cobra.Command) (text, indent bool) {
+	var err error
+	text, err = cmd.Flags().GetBool("text")
+	if err != nil {
+		panic(err)
+	}
+
+	indent, err = cmd.Flags().GetBool("indent")
+	if err != nil {
+		panic(err)
+	}
+	return
+}

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -66,10 +66,10 @@ func updateClientCmd() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress())}, chains[src], cmd)
+			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func createClientCmd() *cobra.Command {
@@ -93,11 +93,11 @@ func createClientCmd() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.CreateClient(dstHeader, chains[src].GetTrustingPeriod(), chains[src].MustGetAddress())}, chains[src], cmd)
+			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.CreateClient(dstHeader, chains[src].GetTrustingPeriod(), chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
 
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func connInit() *cobra.Command {
@@ -120,10 +120,10 @@ func connInit() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.ConnInit(chains[dst].PathEnd, chains[src].MustGetAddress())}, chains[src], cmd)
+			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.ConnInit(chains[dst].PathEnd, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func connTry() *cobra.Command {
@@ -176,10 +176,10 @@ func connTry() *cobra.Command {
 				chains[src].PathEnd.ConnTry(chains[dst].PathEnd, dstConnState, dstConsState, dstCsHeight, chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func connAck() *cobra.Command {
@@ -232,10 +232,10 @@ func connAck() *cobra.Command {
 				chains[src].PathEnd.UpdateClient(hs[dst], chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func connConfirm() *cobra.Command {
@@ -275,10 +275,10 @@ func connConfirm() *cobra.Command {
 				chains[src].PathEnd.UpdateClient(hs[dst], chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func createConnectionStepCmd() *cobra.Command {
@@ -308,11 +308,11 @@ func createConnectionStepCmd() *cobra.Command {
 			}
 
 			if len(msgs.Src) > 0 {
-				if err = SendAndPrint(msgs.Src, chains[src], cmd); err != nil {
+				if err = sendAndPrint(msgs.Src, chains[src], cmd); err != nil {
 					return err
 				}
 			} else if len(msgs.Dst) > 0 {
-				if err = SendAndPrint(msgs.Dst, chains[dst], cmd); err != nil {
+				if err = sendAndPrint(msgs.Dst, chains[dst], cmd); err != nil {
 					return err
 				}
 			}
@@ -321,7 +321,7 @@ func createConnectionStepCmd() *cobra.Command {
 		},
 	}
 
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func chanInit() *cobra.Command {
@@ -349,10 +349,10 @@ func chanInit() *cobra.Command {
 				return fmt.Errorf("invalid order '%s' passed in, expected 'UNORDERED' or 'ORDERED'", args[6])
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.ChanInit(chains[dst].PathEnd, order, chains[src].MustGetAddress())}, chains[src], cmd)
+			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.ChanInit(chains[dst].PathEnd, order, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func chanTry() *cobra.Command {
@@ -390,10 +390,10 @@ func chanTry() *cobra.Command {
 				chains[src].PathEnd.ChanTry(chains[dst].PathEnd, dstChanState, chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func chanAck() *cobra.Command {
@@ -431,10 +431,10 @@ func chanAck() *cobra.Command {
 				chains[src].PathEnd.ChanAck(dstChanState, chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func chanConfirm() *cobra.Command {
@@ -472,10 +472,10 @@ func chanConfirm() *cobra.Command {
 				chains[src].PathEnd.ChanConfirm(dstChanState, chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func createChannelStepCmd() *cobra.Command {
@@ -505,11 +505,11 @@ func createChannelStepCmd() *cobra.Command {
 			}
 
 			if len(msgs.Src) > 0 {
-				if err = SendAndPrint(msgs.Src, chains[src], cmd); err != nil {
+				if err = sendAndPrint(msgs.Src, chains[src], cmd); err != nil {
 					return err
 				}
 			} else if len(msgs.Dst) > 0 {
-				if err = SendAndPrint(msgs.Dst, chains[dst], cmd); err != nil {
+				if err = sendAndPrint(msgs.Dst, chains[dst], cmd); err != nil {
 					return err
 				}
 			}
@@ -518,7 +518,7 @@ func createChannelStepCmd() *cobra.Command {
 		},
 	}
 
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func chanCloseInit() *cobra.Command {
@@ -536,10 +536,10 @@ func chanCloseInit() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{src.PathEnd.ChanCloseInit(src.MustGetAddress())}, src, cmd)
+			return sendAndPrint([]sdk.Msg{src.PathEnd.ChanCloseInit(src.MustGetAddress())}, src, cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func chanCloseConfirm() *cobra.Command {
@@ -577,8 +577,13 @@ func chanCloseConfirm() *cobra.Command {
 				chains[src].PathEnd.ChanCloseConfirm(dstChanState, chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
+}
+
+func sendAndPrint(txs []sdk.Msg, c *relayer.Chain, cmd *cobra.Command) error {
+	text, indent := getPrintingFlags(cmd)
+	return c.SendAndPrint(txs, text, indent)
 }

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -66,7 +66,7 @@ func updateClientCmd() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].UpdateClient(dstHeader)}, chains[src], cmd)
+			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
 	return transactionFlags(cmd)
@@ -93,7 +93,7 @@ func createClientCmd() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].CreateClient(dstHeader)}, chains[src], cmd)
+			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.CreateClient(dstHeader, chains[src].GetTrustingPeriod(), chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
 
@@ -120,7 +120,7 @@ func connInit() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].ConnInit(chains[dst])}, chains[src], cmd)
+			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.ConnInit(chains[dst].PathEnd, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
 	return transactionFlags(cmd)
@@ -172,8 +172,8 @@ func connTry() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].UpdateClient(hs[dst]),
-				chains[src].ConnTry(chains[dst], dstConnState, dstConsState, dstCsHeight),
+				chains[src].PathEnd.UpdateClient(hs[dst], chains[src].MustGetAddress()),
+				chains[src].PathEnd.ConnTry(chains[dst].PathEnd, dstConnState, dstConsState, dstCsHeight, chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -228,8 +228,8 @@ func connAck() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].ConnAck(dstState, dstConsState, dstCsHeight),
-				chains[src].UpdateClient(hs[dst]),
+				chains[src].PathEnd.ConnAck(dstState, dstConsState, dstCsHeight, chains[src].MustGetAddress()),
+				chains[src].PathEnd.UpdateClient(hs[dst], chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -271,8 +271,8 @@ func connConfirm() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].ConnConfirm(dstState),
-				chains[src].UpdateClient(hs[dst]),
+				chains[src].PathEnd.ConnConfirm(dstState, chains[src].MustGetAddress()),
+				chains[src].PathEnd.UpdateClient(hs[dst], chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -349,7 +349,7 @@ func chanInit() *cobra.Command {
 				return fmt.Errorf("invalid order '%s' passed in, expected 'UNORDERED' or 'ORDERED'", args[6])
 			}
 
-			return SendAndPrint([]sdk.Msg{chains[src].ChanInit(chains[dst], order)}, chains[src], cmd)
+			return SendAndPrint([]sdk.Msg{chains[src].PathEnd.ChanInit(chains[dst].PathEnd, order, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
 	return transactionFlags(cmd)
@@ -386,8 +386,8 @@ func chanTry() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].UpdateClient(dstHeader),
-				chains[src].ChanTry(chains[dst], dstChanState),
+				chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress()),
+				chains[src].PathEnd.ChanTry(chains[dst].PathEnd, dstChanState, chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -427,8 +427,8 @@ func chanAck() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].UpdateClient(dstHeader),
-				chains[src].ChanAck(dstChanState),
+				chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress()),
+				chains[src].PathEnd.ChanAck(dstChanState, chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -468,8 +468,8 @@ func chanConfirm() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].UpdateClient(dstHeader),
-				chains[src].ChanConfirm(dstChanState),
+				chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress()),
+				chains[src].PathEnd.ChanConfirm(dstChanState, chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -536,7 +536,7 @@ func chanCloseInit() *cobra.Command {
 				return err
 			}
 
-			return SendAndPrint([]sdk.Msg{src.ChanCloseInit()}, src, cmd)
+			return SendAndPrint([]sdk.Msg{src.PathEnd.ChanCloseInit(src.MustGetAddress())}, src, cmd)
 		},
 	}
 	return transactionFlags(cmd)
@@ -573,8 +573,8 @@ func chanCloseConfirm() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].UpdateClient(dstHeader),
-				chains[src].ChanCloseConfirm(dstChanState),
+				chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress()),
+				chains[src].PathEnd.ChanCloseConfirm(dstChanState, chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -159,7 +159,7 @@ func connTry() *cobra.Command {
 			}
 
 			// We are querying the state of the client for src on dst and finding the height
-			dstClientState, err := chains[dst].QueryClientState(hs[dst].Height)
+			dstClientState, err := chains[dst].QueryClientState()
 			if err != nil {
 				return err
 			}
@@ -215,7 +215,7 @@ func connAck() *cobra.Command {
 			}
 
 			// We are querying the state of the client for src on dst and finding the height
-			dstClientState, err := chains[dst].QueryClientState(hs[dst].Height)
+			dstClientState, err := chains[dst].QueryClientState()
 			if err != nil {
 				return err
 			}

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -159,7 +159,7 @@ func connTry() *cobra.Command {
 			}
 
 			// We are querying the state of the client for src on dst and finding the height
-			dstClientState, err := chains[dst].QueryClientState()
+			dstClientState, err := chains[dst].QueryClientState(hs[dst].Height)
 			if err != nil {
 				return err
 			}
@@ -215,7 +215,7 @@ func connAck() *cobra.Command {
 			}
 
 			// We are querying the state of the client for src on dst and finding the height
-			dstClientState, err := chains[dst].QueryClientState()
+			dstClientState, err := chains[dst].QueryClientState(hs[dst].Height)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ import (
 var (
 	cfgPath     string
 	homePath    string
+	debug       bool
 	config      *Config
 	defaultHome = os.ExpandEnv("$HOME/.relayer")
 	cdc         *codec.Codec
@@ -47,9 +48,11 @@ var (
 func init() {
 	// Register top level flags --home and --config
 	rootCmd.PersistentFlags().StringVar(&homePath, flags.FlagHome, defaultHome, "set home directory")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug output")
 	rootCmd.PersistentFlags().StringVar(&cfgPath, flagConfig, "config.yaml", "set config file")
 	viper.BindPFlag(flags.FlagHome, rootCmd.Flags().Lookup(flags.FlagHome))
 	viper.BindPFlag(flagConfig, rootCmd.Flags().Lookup(flagConfig))
+	viper.BindPFlag("debug", rootCmd.Flags().Lookup("debug"))
 
 	// Register subcommands
 	rootCmd.AddCommand(

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -62,10 +62,10 @@ func createClientsCmd() *cobra.Command {
 				return err
 			}
 
-			return chains[src].CreateClients(chains[dst], cmd)
+			return chains[src].CreateClients(chains[dst])
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func createConnectionCmd() *cobra.Command {
@@ -95,11 +95,11 @@ func createConnectionCmd() *cobra.Command {
 				return err
 			}
 
-			return chains[src].CreateConnection(chains[dst], to, cmd)
+			return chains[src].CreateConnection(chains[dst], to)
 		},
 	}
 
-	return timeoutFlag(transactionFlags(cmd))
+	return timeoutFlag(cmd)
 }
 
 func createChannelCmd() *cobra.Command {
@@ -129,11 +129,11 @@ func createChannelCmd() *cobra.Command {
 				return err
 			}
 
-			return chains[src].CreateChannel(chains[dst], true, to, cmd)
+			return chains[src].CreateChannel(chains[dst], true, to)
 		},
 	}
 
-	return timeoutFlag(transactionFlags(cmd))
+	return timeoutFlag(cmd)
 }
 
 func fullPathCmd() *cobra.Command {
@@ -163,22 +163,22 @@ func fullPathCmd() *cobra.Command {
 			}
 
 			// Check if clients have been created, if not create them
-			if err = chains[src].CreateClients(chains[dst], cmd); err != nil {
+			if err = chains[src].CreateClients(chains[dst]); err != nil {
 				return err
 			}
 
 			// Check if connection has been created, if not create it
-			if err = chains[src].CreateConnection(chains[dst], to, cmd); err != nil {
+			if err = chains[src].CreateConnection(chains[dst], to); err != nil {
 				return err
 			}
 
 			// NOTE: this is hardcoded to create ordered channels right now. Add a flag here to toggle
 			// Check if channel has been created, if not create it
-			return chains[src].CreateChannel(chains[dst], true, to, cmd)
+			return chains[src].CreateChannel(chains[dst], true, to)
 		},
 	}
 
-	return timeoutFlag(transactionFlags(cmd))
+	return timeoutFlag(cmd)
 }
 
 func setPathsFromArgs(src, dst *relayer.Chain, name string) (*relayer.Path, error) {

--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -53,7 +53,7 @@ func xfer() *cobra.Command {
 
 			// MsgTransfer will call SendPacket on src chain
 			txs := relayer.RelayMsgs{
-				Src: []sdk.Msg{chains[src].MsgTransfer(chains[dst], dstHeader.GetHeight(), sdk.NewCoins(amount), dstAddr, source)},
+				Src: []sdk.Msg{chains[src].PathEnd.MsgTransfer(chains[dst].PathEnd, dstHeader.GetHeight(), sdk.NewCoins(amount), dstAddr, source, chains[src].MustGetAddress())},
 				Dst: []sdk.Msg{},
 			}
 
@@ -85,7 +85,7 @@ func xfer() *cobra.Command {
 			}
 
 			// reconstructing packet data here instead of retrieving from an indexed node
-			xferPacket := chains[src].XferPacket(
+			xferPacket := chains[src].PathEnd.XferPacket(
 				sdk.NewCoins(amount),
 				chains[src].MustGetAddress(),
 				dstAddr,
@@ -98,23 +98,24 @@ func xfer() *cobra.Command {
 			// information from an indexing node
 			txs = relayer.RelayMsgs{
 				Dst: []sdk.Msg{
-					chains[dst].UpdateClient(hs[src]),
-					chains[dst].MsgRecvPacket(
-						chains[src],
+					chains[dst].PathEnd.UpdateClient(hs[src], chains[dst].MustGetAddress()),
+					chains[dst].PathEnd.MsgRecvPacket(
+						chains[src].PathEnd,
 						seqRecv.NextSequenceRecv,
 						xferPacket,
 						chanTypes.NewPacketResponse(
 							chains[src].PathEnd.PortID,
 							chains[src].PathEnd.ChannelID,
 							seqSend,
-							chains[dst].NewPacket(
-								chains[src],
+							chains[dst].PathEnd.NewPacket(
+								chains[src].PathEnd,
 								seqSend,
 								xferPacket,
 							),
 							srcCommitRes.Proof.Proof,
 							int64(srcCommitRes.ProofHeight),
 						),
+						chains[dst].MustGetAddress(),
 					),
 				},
 				Src: []sdk.Msg{},
@@ -174,7 +175,7 @@ func xfersend() *cobra.Command {
 			}
 
 			txs := []sdk.Msg{
-				chains[src].MsgTransfer(chains[dst], dstHeader.GetHeight(), sdk.NewCoins(amount), dstAddr, source),
+				chains[src].PathEnd.MsgTransfer(chains[dst].PathEnd, dstHeader.GetHeight(), sdk.NewCoins(amount), dstAddr, source, chains[src].MustGetAddress()),
 			}
 
 			return SendAndPrint(txs, chains[src], cmd)
@@ -226,17 +227,18 @@ func xferrecv() *cobra.Command {
 			// }
 
 			txs := []sdk.Msg{
-				chains[src].UpdateClient(hs[dst]),
-				chains[src].MsgRecvPacket(
-					chains[dst],
+				chains[src].PathEnd.UpdateClient(hs[dst], chains[src].MustGetAddress()),
+				chains[src].PathEnd.MsgRecvPacket(
+					chains[dst].PathEnd,
 					seqRecv.NextSequenceRecv,
-					chains[src].XferPacket(
+					chains[src].PathEnd.XferPacket(
 						sdk.NewCoins(),
 						chains[src].MustGetAddress(),
 						chains[src].MustGetAddress(),
 						false,
 						19291024),
 					chanTypes.PacketResponse{},
+					chains[src].MustGetAddress(),
 				),
 			}
 

--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -57,7 +57,7 @@ func xfer() *cobra.Command {
 				Dst: []sdk.Msg{},
 			}
 
-			if err = txs.Send(chains[src], chains[dst], cmd); err != nil {
+			if err = txs.Send(chains[src], chains[dst]); err != nil {
 				return err
 			}
 
@@ -121,10 +121,10 @@ func xfer() *cobra.Command {
 				Src: []sdk.Msg{},
 			}
 
-			return txs.Send(chains[src], chains[dst], cmd)
+			return txs.Send(chains[src], chains[dst])
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 func xfersend() *cobra.Command {
@@ -178,10 +178,10 @@ func xfersend() *cobra.Command {
 				chains[src].PathEnd.MsgTransfer(chains[dst].PathEnd, dstHeader.GetHeight(), sdk.NewCoins(amount), dstAddr, source, chains[src].MustGetAddress()),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }
 
 // UNTESTED: Currently filled with incorrect logic to make code compile
@@ -242,8 +242,8 @@ func xferrecv() *cobra.Command {
 				),
 			}
 
-			return SendAndPrint(txs, chains[src], cmd)
+			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return transactionFlags(cmd)
+	return cmd
 }

--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -57,8 +58,8 @@ func xfer() *cobra.Command {
 				Dst: []sdk.Msg{},
 			}
 
-			if err = txs.Send(chains[src], chains[dst]); err != nil {
-				return err
+			if txs.Send(chains[src], chains[dst]); !txs.Success() {
+				return fmt.Errorf("failed to send first transaction")
 			}
 
 			// Working on SRC chain :point_up:
@@ -121,7 +122,8 @@ func xfer() *cobra.Command {
 				Src: []sdk.Msg{},
 			}
 
-			return txs.Send(chains[src], chains[dst])
+			txs.Send(chains[src], chains[dst])
+			return nil
 		},
 	}
 	return cmd

--- a/config-relayer.sh
+++ b/config-relayer.sh
@@ -40,6 +40,6 @@ echo "Key $(relayer keys restore ibc1 testkey "$SEED1" -a) imported from ibc1 to
 echo
 echo "Creating lite clients..."
 echo
-sleep 8
+sleep 3
 relayer lite init ibc0 -f
 relayer lite init ibc1 -f

--- a/dev-chains.sh
+++ b/dev-chains.sh
@@ -17,5 +17,5 @@ cd $RELAYER_DIR
 rm -rf $RELAYER_CONF &> /dev/null
 bash two-chains.sh "local" "skip"
 bash config-relayer.sh "skip"
-sleep 5
-relayer tx full-path ibc0 ibc1 -d
+sleep 2
+relayer tx full-path ibc0 ibc1 -d -o 3s

--- a/dev-chains.sh
+++ b/dev-chains.sh
@@ -18,4 +18,4 @@ rm -rf $RELAYER_CONF &> /dev/null
 bash two-chains.sh "local" "skip"
 bash config-relayer.sh "skip"
 sleep 5
-relayer tx full-path ibc0 ibc1
+relayer tx full-path ibc0 ibc1 -d

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -19,7 +19,6 @@ import (
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	libclient "github.com/tendermint/tendermint/rpc/lib/client"
-	"gopkg.in/yaml.v2"
 )
 
 // Chain represents the necessary data for connecting to and indentifying a chain and its counterparites
@@ -46,42 +45,43 @@ type Chain struct {
 	address sdk.AccAddress
 	logger  log.Logger
 	timeout time.Duration
+	debug   bool
 }
 
 // Init initializes the pieces of a chain that aren't set when it parses a config
 // NOTE: All validation of the chain should happen here.
-func (c *Chain) Init(homePath string, cdc *codecstd.Codec, amino *aminocodec.Codec, timeout time.Duration) (*Chain, error) {
-	keybase, err := keys.NewKeyring(c.ChainID, "test", keysDir(homePath), nil)
+func (src *Chain) Init(homePath string, cdc *codecstd.Codec, amino *aminocodec.Codec, timeout time.Duration, debug bool) (*Chain, error) {
+	keybase, err := keys.NewKeyring(src.ChainID, "test", keysDir(homePath), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := newRPCClient(c.RPCAddr, timeout)
+	client, err := newRPCClient(src.RPCAddr, timeout)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = sdk.ParseDecCoins(c.GasPrices)
+	_, err = sdk.ParseDecCoins(src.GasPrices)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = time.ParseDuration(c.TrustingPeriod)
+	_, err = time.ParseDuration(src.TrustingPeriod)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse trusting period (%s) for chain %s", c.TrustingPeriod, c.ChainID)
+		return nil, fmt.Errorf("failed to parse trusting period (%s) for chain %s", src.TrustingPeriod, src.ChainID)
 	}
 
 	return &Chain{
-		Key:            c.Key,
-		ChainID:        c.ChainID,
-		RPCAddr:        c.RPCAddr,
-		AccountPrefix:  c.AccountPrefix,
-		Gas:            c.Gas,
-		GasAdjustment:  c.GasAdjustment,
-		GasPrices:      c.GasPrices,
-		DefaultDenom:   c.DefaultDenom,
-		Memo:           c.Memo,
-		TrustingPeriod: c.TrustingPeriod,
+		Key:            src.Key,
+		ChainID:        src.ChainID,
+		RPCAddr:        src.RPCAddr,
+		AccountPrefix:  src.AccountPrefix,
+		Gas:            src.Gas,
+		GasAdjustment:  src.GasAdjustment,
+		GasPrices:      src.GasPrices,
+		DefaultDenom:   src.DefaultDenom,
+		Memo:           src.Memo,
+		TrustingPeriod: src.TrustingPeriod,
 		Keybase:        keybase,
 		Client:         client,
 		Cdc:            cdc,
@@ -89,16 +89,18 @@ func (c *Chain) Init(homePath string, cdc *codecstd.Codec, amino *aminocodec.Cod
 		HomePath:       homePath,
 		logger:         log.NewTMLogger(log.NewSyncWriter(os.Stdout)),
 		timeout:        timeout,
+		debug:          debug,
 	}, nil
 }
 
-func (c *Chain) getGasPrices() sdk.DecCoins {
-	gp, _ := sdk.ParseDecCoins(c.GasPrices)
+func (src *Chain) getGasPrices() sdk.DecCoins {
+	gp, _ := sdk.ParseDecCoins(src.GasPrices)
 	return gp
 }
 
-func (c *Chain) GetTrustingPeriod() time.Duration {
-	tp, _ := time.ParseDuration(c.TrustingPeriod)
+// GetTrustingPeriod returns the trusting period for the chain
+func (src *Chain) GetTrustingPeriod() time.Duration {
+	tp, _ := time.ParseDuration(src.TrustingPeriod)
 	return tp
 }
 
@@ -116,7 +118,6 @@ func newRPCClient(addr string, timeout time.Duration) (*rpcclient.HTTP, error) {
 	}
 
 	return rpcClient, nil
-
 }
 
 // SendMsg wraps the msg in a stdtx, signs and sends it
@@ -134,47 +135,49 @@ func (src *Chain) SendMsgs(datagrams []sdk.Msg) (res sdk.TxResponse, err error) 
 }
 
 // BuildAndSignTx takes messages and builds, signs and marshals a sdk.Tx to prepare it for broadcast
-func (c *Chain) BuildAndSignTx(datagram []sdk.Msg) ([]byte, error) {
+func (src *Chain) BuildAndSignTx(datagram []sdk.Msg) ([]byte, error) {
 	// Fetch account and sequence numbers for the account
-	acc, err := auth.NewAccountRetriever(c.Cdc, c).GetAccount(c.MustGetAddress())
+	acc, err := auth.NewAccountRetriever(src.Cdc, src).GetAccount(src.MustGetAddress())
 	if err != nil {
 		return nil, err
 	}
 
 	return auth.NewTxBuilder(
-		auth.DefaultTxEncoder(c.Amino), acc.GetAccountNumber(),
-		acc.GetSequence(), c.Gas, c.GasAdjustment, false, c.ChainID,
-		c.Memo, sdk.NewCoins(), c.getGasPrices()).WithKeybase(c.Keybase).
-		BuildAndSign(c.Key, ckeys.DefaultKeyPass, datagram)
+		auth.DefaultTxEncoder(src.Amino), acc.GetAccountNumber(),
+		acc.GetSequence(), src.Gas, src.GasAdjustment, false, src.ChainID,
+		src.Memo, sdk.NewCoins(), src.getGasPrices()).WithKeybase(src.Keybase).
+		BuildAndSign(src.Key, ckeys.DefaultKeyPass, datagram)
 }
 
 // BroadcastTxCommit takes the marshaled transaction bytes and broadcasts them
-func (c *Chain) BroadcastTxCommit(txBytes []byte) (sdk.TxResponse, error) {
-	res, err := sdkCtx.CLIContext{Client: c.Client}.BroadcastTxCommit(txBytes)
-	// NOTE: The raw is a recreation of the log and unused in this context. It is also
-	// quite noisy so we remove it to simplify the output
-	res.RawLog = ""
+func (src *Chain) BroadcastTxCommit(txBytes []byte) (sdk.TxResponse, error) {
+	res, err := sdkCtx.CLIContext{Client: src.Client}.BroadcastTxCommit(txBytes)
+
+	if !src.debug {
+		res.RawLog = ""
+	}
+
 	return res, err
 }
 
 // Log takes a string and logs the data
-func (c *Chain) Log(s string) {
-	c.logger.Info(s)
+func (src *Chain) Log(s string) {
+	src.logger.Info(s)
 }
 
 // Error takes an error, wraps it in the chainID and logs the error
-func (c *Chain) Error(err error) {
-	c.logger.Error(fmt.Sprintf("%s: err(%s)", c.ChainID, err.Error()))
+func (src *Chain) Error(err error) {
+	src.logger.Error(fmt.Sprintf("%s: err(%s)", src.ChainID, err.Error()))
 }
 
 // Subscribe returns channel of events given a query
-func (c *Chain) Subscribe(query string) (<-chan ctypes.ResultEvent, context.CancelFunc, error) {
-	if err := c.Client.OnStart(); err != nil {
+func (src *Chain) Subscribe(query string) (<-chan ctypes.ResultEvent, context.CancelFunc, error) {
+	if err := src.Client.OnStart(); err != nil {
 		return nil, nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	eventChan, err := c.Client.Subscribe(ctx, fmt.Sprintf("%s-subscriber", c.ChainID), query)
+	eventChan, err := src.Client.Subscribe(ctx, fmt.Sprintf("%s-subscriber", src.ChainID), query)
 	return eventChan, cancel, err
 }
 
@@ -188,35 +191,35 @@ func liteDir(home string) string {
 }
 
 // GetAddress returns the sdk.AccAddress associated with the configred key
-func (c *Chain) GetAddress() (sdk.AccAddress, error) {
-	if c.address != nil {
-		return c.address, nil
+func (src *Chain) GetAddress() (sdk.AccAddress, error) {
+	if src.address != nil {
+		return src.address, nil
 	}
 	// Signing key for src chain
-	srcAddr, err := c.Keybase.Get(c.Key)
+	srcAddr, err := src.Keybase.Get(src.Key)
 	if err != nil {
 		return nil, err
 	}
-	c.address = srcAddr.GetAddress()
+	src.address = srcAddr.GetAddress()
 	return srcAddr.GetAddress(), nil
 }
 
 // MustGetAddress used for brevity
-func (c *Chain) MustGetAddress() sdk.AccAddress {
-	srcAddr, err := c.Keybase.Get(c.Key)
+func (src *Chain) MustGetAddress() sdk.AccAddress {
+	srcAddr, err := src.GetAddress()
 	if err != nil {
 		panic(err)
 	}
-	return srcAddr.GetAddress()
+	return srcAddr
 }
 
-func (c *Chain) String() string {
-	return c.ChainID
+func (src *Chain) String() string {
+	return src.ChainID
 }
 
 // Update returns a new chain with updated values
-func (c *Chain) Update(key, value string) (out *Chain, err error) {
-	out = c
+func (src *Chain) Update(key, value string) (out *Chain, err error) {
+	out = src
 	switch key {
 	case "key":
 		out.Key = value
@@ -260,7 +263,7 @@ func (c *Chain) Update(key, value string) (out *Chain, err error) {
 // Print fmt.Printlns the json or yaml representation of whatever is passed in
 // CONTRACT: The cmd calling this function needs to have the "json" and "indent" flags set
 // TODO: better "text" printing here would be a nice to have
-func (c *Chain) Print(toPrint interface{}, text, indent bool) error {
+func (src *Chain) Print(toPrint interface{}, text, indent bool) error {
 	var (
 		out []byte
 		err error
@@ -268,11 +271,11 @@ func (c *Chain) Print(toPrint interface{}, text, indent bool) error {
 
 	switch {
 	case indent:
-		out, err = c.Amino.MarshalJSONIndent(toPrint, "", "  ")
+		out, err = src.Amino.MarshalJSONIndent(toPrint, "", "  ")
 	case text:
-		out, err = yaml.Marshal(&toPrint)
+		out = []byte(fmt.Sprintf("%v", toPrint))
 	default:
-		out, err = c.Amino.MarshalJSON(toPrint)
+		out, err = src.Amino.MarshalJSON(toPrint)
 	}
 
 	if err != nil {
@@ -281,6 +284,23 @@ func (c *Chain) Print(toPrint interface{}, text, indent bool) error {
 
 	fmt.Println(string(out))
 	return nil
+}
+
+// SendAndPrint sends a transaction and prints according to the passed args
+func (src *Chain) SendAndPrint(txs []sdk.Msg, text, indent bool) (err error) {
+	if src.debug {
+		if err = src.Print(txs, text, indent); err != nil {
+			return err
+		}
+	}
+	// SendAndPrint sends the transaction with printing options from the CLI
+	res, err := src.SendMsgs(txs)
+	if err != nil {
+		return err
+	}
+
+	return src.Print(res, text, indent)
+
 }
 
 // Chains is a collection of Chain

--- a/relayer/chain.go
+++ b/relayer/chain.go
@@ -97,7 +97,7 @@ func (c *Chain) getGasPrices() sdk.DecCoins {
 	return gp
 }
 
-func (c *Chain) getTrustingPeriod() time.Duration {
+func (c *Chain) GetTrustingPeriod() time.Duration {
 	tp, _ := time.ParseDuration(c.TrustingPeriod)
 	return tp
 }
@@ -117,6 +117,20 @@ func newRPCClient(addr string, timeout time.Duration) (*rpcclient.HTTP, error) {
 
 	return rpcClient, nil
 
+}
+
+// SendMsg wraps the msg in a stdtx, signs and sends it
+func (src *Chain) SendMsg(datagram sdk.Msg) (sdk.TxResponse, error) {
+	return src.SendMsgs([]sdk.Msg{datagram})
+}
+
+// SendMsgs wraps the msgs in a stdtx, signs and sends it
+func (src *Chain) SendMsgs(datagrams []sdk.Msg) (res sdk.TxResponse, err error) {
+	var out []byte
+	if out, err = src.BuildAndSignTx(datagrams); err != nil {
+		return res, err
+	}
+	return src.BroadcastTxCommit(out)
 }
 
 // BuildAndSignTx takes messages and builds, signs and marshals a sdk.Tx to prepare it for broadcast

--- a/relayer/codespace.go
+++ b/relayer/codespace.go
@@ -1,5 +1,19 @@
 package relayer
 
+import "fmt"
+
+// GetCodespace returns the configuration for a given path
+func GetCodespace(codespace string, code int) (msg string, err error) {
+	if cs, ok := codespaces[codespace]; ok {
+		if val, ok := cs[code]; ok {
+			msg = val
+		}
+	} else {
+		err = fmt.Errorf("codespace for %s(%d) not found in map", codespace, code)
+	}
+	return
+}
+
 var codespaces = map[string]map[int]string{
 	"client": map[int]string{
 		1:  "light client already exists",

--- a/relayer/path.go
+++ b/relayer/path.go
@@ -86,14 +86,6 @@ func (p *Path) Validate() (err error) {
 	return nil
 }
 
-// Equal returns true if the path ends are equivelent, false otherwise
-func (p *Path) Equal(path *Path) bool {
-	if (p.Src.Equal(path.Src) || p.Src.Equal(path.Dst)) && (p.Dst.Equal(path.Src) || p.Dst.Equal(path.Dst)) {
-		return true
-	}
-	return false
-}
-
 // End returns the proper end given a chainID
 func (p *Path) End(chainID string) *PathEnd {
 	if p.Dst.ChainID == chainID {
@@ -107,25 +99,4 @@ func (p *Path) End(chainID string) *PathEnd {
 
 func (p *Path) String() string {
 	return fmt.Sprintf("[%d] %s ->\n %s", p.Index, p.Src.String(), p.Dst.String())
-}
-
-// TODO: add Order chanTypes.Order as a property and wire it up in validation
-// as well as in the transaction commands
-
-// PathEnd represents the local connection identifers for a relay path
-// The path is set on the chain before performing operations
-type PathEnd struct {
-	ChainID      string `yaml:"chain-id,omitempty" json:"chain-id,omitempty"`
-	ClientID     string `yaml:"client-id,omitempty" json:"client-id,omitempty"`
-	ConnectionID string `yaml:"connection-id,omitempty" json:"connection-id,omitempty"`
-	ChannelID    string `yaml:"channel-id,omitempty" json:"channel-id,omitempty"`
-	PortID       string `yaml:"port-id,omitempty" json:"port-id,omitempty"`
-}
-
-// Equal returns true if both path ends are equivelent, false otherwise
-func (p *PathEnd) Equal(path *PathEnd) bool {
-	if p.ChainID == path.ChainID && p.ClientID == path.ClientID && p.ConnectionID == path.ConnectionID && p.PortID == path.PortID && p.ChannelID == path.ChannelID {
-		return true
-	}
-	return false
 }

--- a/relayer/pathEnd.go
+++ b/relayer/pathEnd.go
@@ -1,0 +1,251 @@
+package relayer
+
+import (
+	"time"
+	tmclient "github.com/cosmos/cosmos-sdk/x/ibc/07-tendermint/types"
+	connTypes "github.com/cosmos/cosmos-sdk/x/ibc/03-connection/types"
+	clientTypes "github.com/cosmos/cosmos-sdk/x/ibc/02-client/types"
+	chanTypes "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/types"
+	chanState "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/exported"
+	xferTypes "github.com/cosmos/cosmos-sdk/x/ibc/20-transfer/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// TODO: add Order chanTypes.Order as a property and wire it up in validation
+// as well as in the transaction commands
+
+// PathEnd represents the local connection identifers for a relay path
+// The path is set on the chain before performing operations
+type PathEnd struct {
+	ChainID      string `yaml:"chain-id,omitempty" json:"chain-id,omitempty"`
+	ClientID     string `yaml:"client-id,omitempty" json:"client-id,omitempty"`
+	ConnectionID string `yaml:"connection-id,omitempty" json:"connection-id,omitempty"`
+	ChannelID    string `yaml:"channel-id,omitempty" json:"channel-id,omitempty"`
+	PortID       string `yaml:"port-id,omitempty" json:"port-id,omitempty"`
+}
+
+
+// UpdateClient creates an sdk.Msg to update the client on c with data pulled from cp
+func (src *PathEnd) UpdateClient(dstHeader *tmclient.Header, signer sdk.AccAddress) sdk.Msg {
+	return tmclient.NewMsgUpdateClient(
+		src.ClientID,
+		*dstHeader,
+		signer,
+	)
+}
+
+// CreateClient creates an sdk.Msg to update the client on src with consensus state from dst
+func (src *PathEnd) CreateClient(dstHeader *tmclient.Header, trustingPeriod time.Duration, signer sdk.AccAddress) sdk.Msg {
+	if err := dstHeader.ValidateBasic(dstHeader.ChainID); err != nil {
+		panic(err)
+	}
+	// TODO: figure out how to dynmaically set unbonding time
+	return tmclient.NewMsgCreateClient(
+		src.ClientID,
+		*dstHeader,
+		trustingPeriod,
+		defaultUnbondingTime,
+		signer,
+	)
+}
+
+// ConnInit creates a MsgConnectionOpenInit
+func (src *PathEnd) ConnInit(dst *PathEnd, signer sdk.AccAddress) sdk.Msg {
+	return connTypes.NewMsgConnectionOpenInit(
+		src.ConnectionID,
+		src.ClientID,
+		dst.ConnectionID,
+		dst.ClientID,
+		defaultChainPrefix,
+		signer,
+	)
+}
+
+// ConnTry creates a MsgConnectionOpenTry
+// NOTE: ADD NOTE ABOUT PROOF HEIGHT CHANGE HERE
+func (src *PathEnd) ConnTry(dst *PathEnd, dstConnState connTypes.ConnectionResponse, dstConsState clientTypes.ConsensusStateResponse, dstCsHeight int64, signer sdk.AccAddress) sdk.Msg {
+	return connTypes.NewMsgConnectionOpenTry(
+		src.ConnectionID,
+		src.ClientID,
+		dst.ConnectionID,
+		dst.ClientID,
+		defaultChainPrefix,
+		defaultIBCVersions,
+		dstConnState.Proof,
+		dstConsState.Proof,
+		dstConnState.ProofHeight+1,
+		uint64(dstCsHeight),
+		signer,
+	)
+}
+
+// ConnAck creates a MsgConnectionOpenAck
+// NOTE: ADD NOTE ABOUT PROOF HEIGHT CHANGE HERE
+func (src *PathEnd) ConnAck(dstConnState connTypes.ConnectionResponse, dstConsState clientTypes.ConsensusStateResponse, dstCsHeight int64, signer sdk.AccAddress) sdk.Msg {
+	return connTypes.NewMsgConnectionOpenAck(
+		src.ConnectionID,
+		dstConnState.Proof,
+		dstConsState.Proof,
+		dstConnState.ProofHeight+1,
+		uint64(dstCsHeight),
+		defaultIBCVersion,
+		signer,
+	)
+}
+
+// ConnConfirm creates a MsgConnectionOpenAck
+// NOTE: ADD NOTE ABOUT PROOF HEIGHT CHANGE HERE
+func (src *PathEnd) ConnConfirm(dstConnState connTypes.ConnectionResponse, signer sdk.AccAddress) sdk.Msg {
+	return connTypes.NewMsgConnectionOpenConfirm(
+		src.ConnectionID,
+		dstConnState.Proof,
+		dstConnState.ProofHeight+1,
+		signer,
+	)
+}
+
+// ChanInit creates a MsgChannelOpenInit
+func (src *PathEnd) ChanInit(dst *PathEnd, ordering chanState.Order, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgChannelOpenInit(
+		src.PortID,
+		src.ChannelID,
+		defaultIBCVersion,
+		ordering,
+		[]string{src.ConnectionID},
+		dst.PortID,
+		dst.ChannelID,
+		signer,
+	)
+}
+
+// ChanTry creates a MsgChannelOpenTry
+func (src *PathEnd) ChanTry(dst *PathEnd, dstChanState chanTypes.ChannelResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgChannelOpenTry(
+		src.PortID,
+		src.ChannelID,
+		defaultIBCVersion,
+		dstChanState.Channel.Ordering,
+		[]string{src.ConnectionID},
+		dst.PortID,
+		dst.ChannelID,
+		defaultIBCVersion,
+		dstChanState.Proof,
+		dstChanState.ProofHeight+1,
+		signer,
+	)
+}
+
+// ChanAck creates a MsgChannelOpenAck
+func (src *PathEnd) ChanAck(dstChanState chanTypes.ChannelResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgChannelOpenAck(
+		src.PortID,
+		src.ChannelID,
+		dstChanState.Channel.GetVersion(),
+		dstChanState.Proof,
+		dstChanState.ProofHeight+1,
+		signer,
+	)
+}
+
+// ChanConfirm creates a MsgChannelOpenConfirm
+func (src *PathEnd) ChanConfirm(dstChanState chanTypes.ChannelResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgChannelOpenConfirm(
+		src.PortID,
+		src.ChannelID,
+		dstChanState.Proof,
+		dstChanState.ProofHeight+1,
+		signer,
+	)
+}
+
+// ChanCloseInit creates a MsgChannelCloseInit
+func (src *PathEnd) ChanCloseInit(signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgChannelCloseInit(
+		src.PortID,
+		src.ChannelID,
+		signer,
+	)
+}
+
+// ChanCloseConfirm creates a MsgChannelCloseConfirm
+func (src *PathEnd) ChanCloseConfirm(dstChanState chanTypes.ChannelResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgChannelCloseConfirm(
+		src.PortID,
+		src.ChannelID,
+		dstChanState.Proof,
+		dstChanState.ProofHeight+1,
+		signer,
+	)
+}
+
+// MsgRecvPacket creates a MsgPacket
+func (src *PathEnd) MsgRecvPacket(dst *PathEnd, sequence uint64, packetData chanState.PacketDataI, proof chanTypes.PacketResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgPacket(
+		src.NewPacket(
+			dst,
+			sequence,
+			packetData,
+		),
+		proof.Proof,
+		proof.ProofHeight+1,
+		signer,
+	)
+}
+
+// MsgTimeout creates MsgTimeout
+func (src *PathEnd) MsgTimeout(packet chanTypes.Packet, seq uint64, proof chanTypes.PacketResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgTimeout(
+		packet,
+		seq,
+		proof.Proof,
+		proof.ProofHeight+1,
+		signer,
+	)
+}
+
+// MsgAck creates MsgAck
+func (src *PathEnd) MsgAck(packet chanTypes.Packet, ack chanState.PacketAcknowledgementI, proof chanTypes.PacketResponse, signer sdk.AccAddress) sdk.Msg {
+	return chanTypes.NewMsgAcknowledgement(
+		packet,
+		ack,
+		proof.Proof,
+		proof.ProofHeight+1,
+		signer,
+	)
+}
+
+// MsgTransfer creates a new transfer message
+func (src *PathEnd) MsgTransfer(dst *PathEnd, dstHeight uint64, amount sdk.Coins, dstAddr sdk.AccAddress, source bool, signer sdk.AccAddress) sdk.Msg {
+	return xferTypes.NewMsgTransfer(
+		src.PortID,
+		src.ChannelID,
+		dstHeight,
+		amount,
+		signer,
+		dstAddr,
+		source,
+	)
+}
+
+// NewPacket returns a new packet from src to dist w
+func (src *PathEnd) NewPacket(dst *PathEnd, sequence uint64, packetData chanState.PacketDataI) chanTypes.Packet {
+	return chanTypes.NewPacket(
+		packetData,
+		sequence,
+		src.PortID,
+		src.ChannelID,
+		dst.PortID,
+		dst.ChannelID,
+	)
+}
+
+// XferPacket creates a new transfer packet
+func (src *PathEnd) XferPacket(amount sdk.Coins, sender, reciever sdk.AccAddress, source bool, timeout uint64) chanState.PacketDataI {
+	return xferTypes.NewFungibleTokenPacketData(
+		amount,
+		sender,
+		reciever,
+		source,
+		timeout,
+	)
+}

--- a/relayer/query.go
+++ b/relayer/query.go
@@ -70,7 +70,7 @@ func (c *Chain) QueryConsensusState(height int64) (*tmclient.ConsensusState, err
 
 // QueryClientConsensusState retrevies the latest consensus state for a client in state at a given height
 // NOTE: dstHeight is the height from dst that is stored on src, it is needed to construct the appropriate store query
-func (c *Chain) QueryClientConsensusState(srcHeight, dstHeight int64) (clientTypes.ConsensusStateResponse, error) {
+func (c *Chain) QueryClientConsensusState(srcHeight, srcClientConsHeight int64) (clientTypes.ConsensusStateResponse, error) {
 	var conStateRes clientTypes.ConsensusStateResponse
 	if !c.PathSet() {
 		return conStateRes, c.ErrPathNotSet()
@@ -79,7 +79,7 @@ func (c *Chain) QueryClientConsensusState(srcHeight, dstHeight int64) (clientTyp
 	req := abci.RequestQuery{
 		Path:   "store/ibc/key",
 		Height: int64(srcHeight),
-		Data:   ibctypes.KeyConsensusState(c.PathEnd.ClientID, uint64(dstHeight)),
+		Data:   ibctypes.KeyConsensusState(c.PathEnd.ClientID, uint64(srcClientConsHeight)),
 		Prove:  true,
 	}
 
@@ -99,19 +99,65 @@ func (c *Chain) QueryClientConsensusState(srcHeight, dstHeight int64) (clientTyp
 	return clientTypes.NewConsensusStateResponse(c.PathEnd.ClientID, cs, res.Proof, res.Height), nil
 }
 
+type csstates struct {
+	sync.Mutex
+	Map  map[string]clientTypes.ConsensusStateResponse
+	Errs errs
+}
+
+type chh struct {
+	c   *Chain
+	h   int64
+	csh int64
+}
+
+// QueryClientConsensusStatePair allows for the querying of multiple client states at the same time
+func QueryClientConsensusStatePair(src, dst *Chain, srcH, dstH, srcClientConsH, dstClientConsH int64) (map[string]clientTypes.ConsensusStateResponse, error) {
+	hs := &csstates{
+		Map:  make(map[string]clientTypes.ConsensusStateResponse),
+		Errs: []error{},
+	}
+
+	var wg sync.WaitGroup
+
+	chps := []chh{
+		chh{src, srcH, srcClientConsH},
+		chh{dst, dstH, dstClientConsH},
+	}
+
+	for _, chain := range chps {
+		wg.Add(1)
+		go func(hs *csstates, wg *sync.WaitGroup, chp chh) {
+			conn, err := chp.c.QueryClientConsensusState(chp.h, chp.csh)
+			if err != nil {
+				hs.Lock()
+				hs.Errs = append(hs.Errs, err)
+				hs.Unlock()
+			}
+			hs.Lock()
+			hs.Map[chp.c.ChainID] = conn
+			hs.Unlock()
+			wg.Done()
+		}(hs, &wg, chain)
+	}
+	wg.Wait()
+	return hs.Map, hs.Errs.err()
+}
+
 func qClntConsStateErr(err error) error { return fmt.Errorf("query client cons state failed: %w", err) }
 
 // QueryClientState retrevies the latest consensus state for a client in state at a given height
-func (c *Chain) QueryClientState() (clientTypes.StateResponse, error) {
+func (c *Chain) QueryClientState(height int64) (clientTypes.StateResponse, error) {
 	var conStateRes clientTypes.StateResponse
 	if !c.PathSet() {
 		return conStateRes, c.ErrPathNotSet()
 	}
 
 	req := abci.RequestQuery{
-		Path:  "store/ibc/key",
-		Data:  ibctypes.KeyClientState(c.PathEnd.ClientID),
-		Prove: true,
+		Path:   "store/ibc/key",
+		Height: height,
+		Data:   ibctypes.KeyClientState(c.PathEnd.ClientID),
+		Prove:  true,
 	}
 
 	res, err := c.QueryABCI(req)
@@ -128,6 +174,45 @@ func (c *Chain) QueryClientState() (clientTypes.StateResponse, error) {
 	}
 
 	return clientTypes.NewClientStateResponse(c.PathEnd.ClientID, cs, res.Proof, res.Height), nil
+}
+
+type cstates struct {
+	sync.Mutex
+	Map  map[string]clientTypes.StateResponse
+	Errs errs
+}
+
+// QueryClientStatePair returns a pair of connection responses
+func QueryClientStatePair(src, dst *Chain, srcH, dstH int64) (map[string]clientTypes.StateResponse, error) {
+	hs := &cstates{
+		Map:  make(map[string]clientTypes.StateResponse),
+		Errs: []error{},
+	}
+
+	var wg sync.WaitGroup
+
+	chps := []chpair{
+		chpair{src, srcH},
+		chpair{dst, dstH},
+	}
+
+	for _, chain := range chps {
+		wg.Add(1)
+		go func(hs *cstates, wg *sync.WaitGroup, chp chpair) {
+			conn, err := chp.c.QueryClientState(chp.h)
+			if err != nil {
+				hs.Lock()
+				hs.Errs = append(hs.Errs, err)
+				hs.Unlock()
+			}
+			hs.Lock()
+			hs.Map[chp.c.ChainID] = conn
+			hs.Unlock()
+			wg.Done()
+		}(hs, &wg, chain)
+	}
+	wg.Wait()
+	return hs.Map, hs.Errs.err()
 }
 
 func qClntStateErr(err error) error { return fmt.Errorf("query client state failed: %w", err) }
@@ -240,6 +325,55 @@ func (c *Chain) QueryConnection(height int64) (connTypes.ConnectionResponse, err
 	return connTypes.NewConnectionResponse(c.PathEnd.ConnectionID, connection, res.Proof, res.Height), nil
 }
 
+type conns struct {
+	sync.Mutex
+	Map  map[string]connTypes.ConnectionResponse
+	Errs errs
+}
+
+type chpair struct {
+	c *Chain
+	h int64
+}
+
+// QueryConnectionPair returns a pair of connection responses
+func QueryConnectionPair(src, dst *Chain, srcH, dstH int64) (map[string]connTypes.ConnectionResponse, error) {
+	hs := &conns{
+		Map:  make(map[string]connTypes.ConnectionResponse),
+		Errs: []error{},
+	}
+
+	var wg sync.WaitGroup
+
+	chps := []chpair{
+		chpair{src, srcH},
+		chpair{dst, dstH},
+	}
+
+	for _, chain := range chps {
+		wg.Add(1)
+		go func(hs *conns, wg *sync.WaitGroup, chp chpair) {
+			conn, err := chp.c.QueryConnection(chp.h)
+			if err != nil {
+				hs.Lock()
+				hs.Errs = append(hs.Errs, err)
+				hs.Unlock()
+			}
+			hs.Lock()
+			hs.Map[chp.c.ChainID] = conn
+			hs.Unlock()
+			wg.Done()
+		}(hs, &wg, chain)
+	}
+	wg.Wait()
+	return hs.Map, hs.Errs.err()
+}
+
+// // QueryLatestHeights returns the heights of multiple chains at once
+// func QueryLatestHeights(chains ...*Chain) (map[string]int64, error) {
+
+// }
+
 func qConnErr(err error) error { return fmt.Errorf("query connection failed: %w", err) }
 
 var emptyConnRes = connTypes.ConnectionResponse{Connection: connTypes.ConnectionEnd{State: connState.UNINITIALIZED}}
@@ -275,6 +409,45 @@ func (c *Chain) QueryChannel(height int64) (chanRes chanTypes.ChannelResponse, e
 	}
 
 	return chanTypes.NewChannelResponse(c.PathEnd.PortID, c.PathEnd.ChannelID, channel, res.Proof, res.Height), nil
+}
+
+type chans struct {
+	sync.Mutex
+	Map  map[string]chanTypes.ChannelResponse
+	Errs errs
+}
+
+// QueryChannelPair returns a pair of connection responses
+func QueryChannelPair(src, dst *Chain, srcH, dstH int64) (map[string]chanTypes.ChannelResponse, error) {
+	hs := &chans{
+		Map:  make(map[string]chanTypes.ChannelResponse),
+		Errs: []error{},
+	}
+
+	var wg sync.WaitGroup
+
+	chps := []chpair{
+		chpair{src, srcH},
+		chpair{dst, dstH},
+	}
+
+	for _, chain := range chps {
+		wg.Add(1)
+		go func(hs *chans, wg *sync.WaitGroup, chp chpair) {
+			conn, err := chp.c.QueryChannel(chp.h)
+			if err != nil {
+				hs.Lock()
+				hs.Errs = append(hs.Errs, err)
+				hs.Unlock()
+			}
+			hs.Lock()
+			hs.Map[chp.c.ChainID] = conn
+			hs.Unlock()
+			wg.Done()
+		}(hs, &wg, chain)
+	}
+	wg.Wait()
+	return hs.Map, hs.Errs.err()
 }
 
 func qChanErr(err error) error { return fmt.Errorf("query channel failed: %w", err) }
@@ -538,12 +711,14 @@ func (c *Chain) QueryLatestHeight() (int64, error) {
 type heights struct {
 	sync.Mutex
 	Map  map[string]int64
-	Errs []error
+	Errs errs
 }
 
-func (h *heights) err() error {
+type errs []error
+
+func (e errs) err() error {
 	var out error
-	for _, err := range h.Errs {
+	for _, err := range e {
 		out = fmt.Errorf("err: %w ", err)
 	}
 	return out
@@ -570,7 +745,7 @@ func QueryLatestHeights(chains ...*Chain) (map[string]int64, error) {
 		}(hs, &wg, chain)
 	}
 	wg.Wait()
-	return hs.Map, hs.err()
+	return hs.Map, hs.Errs.err()
 }
 
 // QueryLatestHeader returns the latest header from the chain

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -11,6 +11,9 @@ import (
 type RelayMsgs struct {
 	Src []sdk.Msg
 	Dst []sdk.Msg
+
+	last    bool
+	success bool
 }
 
 // Ready returns true if there are messages to relay
@@ -21,18 +24,23 @@ func (r *RelayMsgs) Ready() bool {
 	return true
 }
 
+// Success returns the success var
+func (r *RelayMsgs) Success() bool {
+	return r.success
+}
+
 // Send sends the messages with appropriate output
-func (r *RelayMsgs) Send(src, dst *Chain) error {
+func (r *RelayMsgs) Send(src, dst *Chain) {
+	var failed = false
 	// TODO: maybe figure out a better way to indicate error here?
-	var out error
 
 	// TODO: Parallelize? Maybe?
 	if len(r.Src) > 0 {
 		// Submit the transactions to src chain
 		res, err := src.SendMsgs(r.Src)
 		if err != nil || res.Code != 0 {
-			out = err
-			src.LogFailedTx(res, r.Src)
+			src.LogFailedTx(res, err, r.Src)
+			failed = true
 		} else {
 			// NOTE: Add more data to this such as identifiers
 			src.LogSuccessTx(res, r.Src)
@@ -43,31 +51,43 @@ func (r *RelayMsgs) Send(src, dst *Chain) error {
 		// Submit the transactions to dst chain
 		res, err := dst.SendMsgs(r.Dst)
 		if err != nil || res.Code != 0 {
-			out = err
-			dst.LogFailedTx(res, r.Dst)
+			dst.LogFailedTx(res, err, r.Dst)
+			failed = true
 		} else {
 			// NOTE: Add more data to this such as identifiers
 			dst.LogSuccessTx(res, r.Dst)
+
 		}
 	}
 
-	return out
+	if failed {
+		r.success = false
+		return
+	}
+	r.success = true
+	return
 }
 
 // LogFailedTx takes the transaction and the messages to create it and logs the appropriate data
-func (c *Chain) LogFailedTx(res sdk.TxResponse, msgs []sdk.Msg) {
+func (c *Chain) LogFailedTx(res sdk.TxResponse, err error, msgs []sdk.Msg) {
 	if c.debug {
 		c.Log(fmt.Sprintf("- [%s] -> sending transaction:", c.ChainID))
 		c.Print(msgs, false, false)
 	}
 
-	msg, err := GetCodespace(res.Codespace, int(res.Code))
 	if err != nil {
-		c.logger.Info(err.Error())
+		c.logger.Error(fmt.Sprintf("- [%s] -> err(%w)", c.ChainID, err))
 	}
 
-	c.logger.Info(fmt.Sprintf("✘ [%s]@{%d} - msg(%s) err(%s: %s)", c.ChainID, res.Height, getMsgAction(msgs), res.Codespace, msg))
-	if c.debug {
+	if res.Codespace != "" && res.Code != 0 {
+		msg, err := GetCodespace(res.Codespace, int(res.Code))
+		if err != nil {
+			c.logger.Info(err.Error())
+		}
+		c.logger.Info(fmt.Sprintf("✘ [%s]@{%d} - msg(%s) err(%s: %s)", c.ChainID, res.Height, getMsgAction(msgs), res.Codespace, msg))
+	}
+
+	if c.debug && !res.Empty() {
 		c.Print(res, false, false)
 	}
 }

--- a/relayer/relayMsgs.go
+++ b/relayer/relayMsgs.go
@@ -23,11 +23,15 @@ func (r *RelayMsgs) Ready() bool {
 
 // Send sends the messages with appropriate output
 func (r *RelayMsgs) Send(src, dst *Chain) error {
-	// SendRelayMsgs sends the msgs to their chains
+	// TODO: maybe figure out a better way to indicate error here?
+	var out error
+
+	// TODO: Parallelize? Maybe?
 	if len(r.Src) > 0 {
 		// Submit the transactions to src chain
 		res, err := src.SendMsgs(r.Src)
 		if err != nil || res.Code != 0 {
+			out = err
 			src.LogFailedTx(res, r.Src)
 		} else {
 			// NOTE: Add more data to this such as identifiers
@@ -39,6 +43,7 @@ func (r *RelayMsgs) Send(src, dst *Chain) error {
 		// Submit the transactions to dst chain
 		res, err := dst.SendMsgs(r.Dst)
 		if err != nil || res.Code != 0 {
+			out = err
 			dst.LogFailedTx(res, r.Dst)
 		} else {
 			// NOTE: Add more data to this such as identifiers
@@ -46,14 +51,7 @@ func (r *RelayMsgs) Send(src, dst *Chain) error {
 		}
 	}
 
-	return nil
-}
-
-func debug(src, dst *Chain) bool {
-	if src.debug && dst.debug {
-		return true
-	}
-	return false
+	return out
 }
 
 // LogFailedTx takes the transaction and the messages to create it and logs the appropriate data

--- a/relayer/tx.go
+++ b/relayer/tx.go
@@ -6,9 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clientTypes "github.com/cosmos/cosmos-sdk/x/ibc/02-client/types"
 	connState "github.com/cosmos/cosmos-sdk/x/ibc/03-connection/exported"
-	connTypes "github.com/cosmos/cosmos-sdk/x/ibc/03-connection/types"
 	chanState "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/exported"
-	chanTypes "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/types"
 	commitmentypes "github.com/cosmos/cosmos-sdk/x/ibc/23-commitment/types"
 	"github.com/spf13/cobra"
 )
@@ -24,15 +22,9 @@ var (
 func (src *Chain) CreateClients(dst *Chain, cmd *cobra.Command) (err error) {
 	clients := &RelayMsgs{Src: []sdk.Msg{}, Dst: []sdk.Msg{}}
 
-	// Get latest src height for querying the client state
-	srcH, err := src.GetLatestLiteHeight()
-	if err != nil {
-		return err
-	}
-
 	// Create client for dst on src if it doesn't exist
 	var srcCs, dstCs clientTypes.StateResponse
-	if srcCs, err = src.QueryClientState(srcH); err != nil {
+	if srcCs, err = src.QueryClientState(); err != nil {
 		return err
 	} else if srcCs.ClientState == nil {
 		dstH, err := dst.UpdateLiteWithHeader()
@@ -43,14 +35,8 @@ func (src *Chain) CreateClients(dst *Chain, cmd *cobra.Command) (err error) {
 	}
 	// TODO: maybe log something here that the client has been created?
 
-	// Get latest dst height for querying the client state
-	dstH, err := dst.GetLatestLiteHeight()
-	if err != nil {
-		return err
-	}
-
 	// Create client for src on dst if it doesn't exist
-	if dstCs, err = dst.QueryClientState(dstH); err != nil {
+	if dstCs, err = dst.QueryClientState(); err != nil {
 		return err
 	} else if dstCs.ClientState == nil {
 		srcH, err := src.UpdateLiteWithHeader()
@@ -110,83 +96,78 @@ func (src *Chain) CreateConnectionStep(dst *Chain) (*RelayMsgs, error) {
 		return nil, err
 	}
 
+	scid, dcid := src.ChainID, dst.ChainID
+
 	// Query Connection data from src and dst
 	// NOTE: We query connection at height - 1 because of the way tendermint returns
 	// proofs the commit for height n is contained in the header of height n + 1
-	var srcEnd, dstEnd connTypes.ConnectionResponse
-	if srcEnd, err = src.QueryConnection(hs[src.ChainID].Height - 1); err != nil {
-		return nil, err
-	}
-	if dstEnd, err = dst.QueryConnection(hs[src.ChainID].Height - 1); err != nil {
+	conn, err := QueryConnectionPair(src, dst, hs[scid].Height-1, hs[dcid].Height-1)
+	if err != nil {
 		return nil, err
 	}
 
-	// Query Client heights from chains src and dst
-	var csSrc, csDst clientTypes.StateResponse
-	if csSrc, err = src.QueryClientState(hs[src.ChainID].Height); err != nil {
-		return nil, err
-	}
-	if csDst, err = dst.QueryClientState(hs[dst.ChainID].Height); err != nil {
+	// NOTE: We query connection at height - 1 because of the way tendermint returns
+	// proofs the commit for height n is contained in the header of height n + 1
+	cs, err := QueryClientStatePair(src, dst)
+	if err != nil {
 		return nil, err
 	}
 
 	// Store the heights
-	srcConsH, dstConsH := int64(csSrc.ClientState.GetLatestHeight()), int64(csDst.ClientState.GetLatestHeight())
+	srcConsH, dstConsH := int64(cs[scid].ClientState.GetLatestHeight()), int64(cs[dcid].ClientState.GetLatestHeight())
 
-	// Query the stored client consensus states at those heights on both src and dst
-	var srcCons, dstCons clientTypes.ConsensusStateResponse
-	if srcCons, err = src.QueryClientConsensusState(hs[src.ChainID].Height-1, srcConsH); err != nil {
-		return nil, err
-	}
-	if dstCons, err = dst.QueryClientConsensusState(hs[dst.ChainID].Height-1, dstConsH); err != nil {
+	// NOTE: We query connection at height - 1 because of the way tendermint returns
+	// proofs the commit for height n is contained in the header of height n + 1
+	cons, err := QueryClientConsensusStatePair(src, dst, hs[scid].Height-1, hs[dcid].Height-1, srcConsH, dstConsH)
+	if err != nil {
 		return nil, err
 	}
 
 	switch {
 	// Handshake hasn't been started on src or dst, relay `connOpenInit` to src
-	case srcEnd.Connection.State == connState.UNINITIALIZED && dstEnd.Connection.State == connState.UNINITIALIZED:
+	case conn[scid].Connection.State == connState.UNINITIALIZED && conn[dcid].Connection.State == connState.UNINITIALIZED:
 		out.Src = append(out.Src, src.PathEnd.ConnInit(dst.PathEnd, src.MustGetAddress()))
 
 	// Handshake has started on dst (1 stepdone), relay `connOpenTry` and `updateClient` on src
-	case srcEnd.Connection.State == connState.UNINITIALIZED && dstEnd.Connection.State == connState.INIT:
+	case conn[scid].Connection.State == connState.UNINITIALIZED && conn[dcid].Connection.State == connState.INIT:
 		out.Src = append(out.Src,
-			src.PathEnd.UpdateClient(hs[dst.ChainID], src.MustGetAddress()),
-			src.PathEnd.ConnTry(dst.PathEnd, dstEnd, dstCons, dstConsH, src.MustGetAddress()),
+			src.PathEnd.UpdateClient(hs[dcid], src.MustGetAddress()),
+			src.PathEnd.ConnTry(dst.PathEnd, conn[dcid], cons[dcid], dstConsH, src.MustGetAddress()),
 		)
 
 	// Handshake has started on src (1 step done), relay `connOpenTry` and `updateClient` on dst
-	case srcEnd.Connection.State == connState.INIT && dstEnd.Connection.State == connState.UNINITIALIZED:
+	case conn[scid].Connection.State == connState.INIT && conn[dcid].Connection.State == connState.UNINITIALIZED:
 		out.Dst = append(out.Dst,
-			dst.PathEnd.UpdateClient(hs[src.ChainID], dst.MustGetAddress()),
-			dst.PathEnd.ConnTry(src.PathEnd, srcEnd, srcCons, srcConsH, dst.MustGetAddress()),
+			dst.PathEnd.UpdateClient(hs[scid], dst.MustGetAddress()),
+			dst.PathEnd.ConnTry(src.PathEnd, conn[scid], cons[scid], srcConsH, dst.MustGetAddress()),
 		)
 
 	// Handshake has started on src end (2 steps done), relay `connOpenAck` and `updateClient` to dst end
-	case srcEnd.Connection.State == connState.TRYOPEN && dstEnd.Connection.State == connState.INIT:
+	case conn[scid].Connection.State == connState.TRYOPEN && conn[dcid].Connection.State == connState.INIT:
 		out.Dst = append(out.Dst,
-			dst.PathEnd.UpdateClient(hs[src.ChainID], dst.MustGetAddress()),
-			dst.PathEnd.ConnAck(srcEnd, srcCons, srcConsH, dst.MustGetAddress()),
+			dst.PathEnd.UpdateClient(hs[scid], dst.MustGetAddress()),
+			dst.PathEnd.ConnAck(conn[scid], cons[scid], srcConsH, dst.MustGetAddress()),
 		)
 
 	// Handshake has started on dst end (2 steps done), relay `connOpenAck` and `updateClient` to src end
-	case srcEnd.Connection.State == connState.INIT && dstEnd.Connection.State == connState.TRYOPEN:
+	case conn[scid].Connection.State == connState.INIT && conn[dcid].Connection.State == connState.TRYOPEN:
 		out.Src = append(out.Src,
-			src.PathEnd.UpdateClient(hs[dst.ChainID], src.MustGetAddress()),
-			src.PathEnd.ConnAck(dstEnd, dstCons, dstConsH, src.MustGetAddress()),
+			src.PathEnd.UpdateClient(hs[dcid], src.MustGetAddress()),
+			src.PathEnd.ConnAck(conn[dcid], cons[dcid], dstConsH, src.MustGetAddress()),
 		)
 
 	// Handshake has confirmed on dst (3 steps done), relay `connOpenConfirm` and `updateClient` to src end
-	case srcEnd.Connection.State == connState.TRYOPEN && dstEnd.Connection.State == connState.OPEN:
+	case conn[scid].Connection.State == connState.TRYOPEN && conn[dcid].Connection.State == connState.OPEN:
 		out.Src = append(out.Src,
-			src.PathEnd.UpdateClient(hs[dst.ChainID], src.MustGetAddress()),
-			src.PathEnd.ConnConfirm(dstEnd, src.MustGetAddress()),
+			src.PathEnd.UpdateClient(hs[dcid], src.MustGetAddress()),
+			src.PathEnd.ConnConfirm(conn[dcid], src.MustGetAddress()),
 		)
 
 	// Handshake has confirmed on src (3 steps done), relay `connOpenConfirm` and `updateClient` to dst end
-	case srcEnd.Connection.State == connState.OPEN && dstEnd.Connection.State == connState.TRYOPEN:
+	case conn[scid].Connection.State == connState.OPEN && conn[dcid].Connection.State == connState.TRYOPEN:
 		out.Dst = append(out.Dst,
-			dst.PathEnd.UpdateClient(hs[src.ChainID], dst.MustGetAddress()),
-			dst.PathEnd.ConnConfirm(srcEnd, dst.MustGetAddress()),
+			dst.PathEnd.UpdateClient(hs[scid], dst.MustGetAddress()),
+			dst.PathEnd.ConnConfirm(conn[scid], dst.MustGetAddress()),
 		)
 	}
 
@@ -236,67 +217,65 @@ func (src *Chain) CreateChannelStep(dst *Chain, ordering chanState.Order) (*Rela
 		return nil, dst.ErrCantSetPath(err)
 	}
 
+	scid, dcid := src.ChainID, dst.ChainID
+
 	hs, err := UpdatesWithHeaders(src, dst)
 	if err != nil {
 		return nil, err
 	}
 
-	var srcEnd, dstEnd chanTypes.ChannelResponse
-	if dstEnd, err = dst.QueryChannel(hs[dst.ChainID].Height - 1); err != nil {
-		return nil, err
-	}
-
-	if srcEnd, err = src.QueryChannel(hs[src.ChainID].Height - 1); err != nil {
+	chans, err := QueryChannelPair(src, dst, hs[scid].Height-1, hs[dcid].Height-1)
+	if err != nil {
 		return nil, err
 	}
 
 	switch {
 	// Handshake hasn't been started on src or dst, relay `chanOpenInit` to src
-	case srcEnd.Channel.State == chanState.UNINITIALIZED && dstEnd.Channel.State == chanState.UNINITIALIZED:
+	case chans[scid].Channel.State == chanState.UNINITIALIZED && chans[dcid].Channel.State == chanState.UNINITIALIZED:
 		out.Src = append(out.Src,
 			src.PathEnd.ChanInit(dst.PathEnd, ordering, src.MustGetAddress()),
 		)
 
 	// Handshake has started on dst (1 step done), relay `chanOpenTry` and `updateClient` to src
-	case srcEnd.Channel.State == chanState.UNINITIALIZED && dstEnd.Channel.State == chanState.INIT:
+	case chans[scid].Channel.State == chanState.UNINITIALIZED && chans[dcid].Channel.State == chanState.INIT:
 		out.Src = append(out.Src,
-			src.PathEnd.UpdateClient(hs[dst.ChainID], src.MustGetAddress()),
-			src.PathEnd.ChanTry(dst.PathEnd, dstEnd, src.MustGetAddress()),
+			src.PathEnd.UpdateClient(hs[dcid], src.MustGetAddress()),
+			src.PathEnd.ChanTry(dst.PathEnd, chans[dcid], src.MustGetAddress()),
 		)
 
 	// Handshake has started on src (1 step done), relay `chanOpenTry` and `updateClient` to dst
-	case srcEnd.Channel.State == chanState.INIT && dstEnd.Channel.State == chanState.UNINITIALIZED:
+	case chans[scid].Channel.State == chanState.INIT && chans[dcid].Channel.State == chanState.UNINITIALIZED:
 		out.Dst = append(out.Dst,
-			dst.PathEnd.UpdateClient(hs[src.ChainID], dst.MustGetAddress()),
-			dst.PathEnd.ChanTry(src.PathEnd, srcEnd, dst.MustGetAddress()),
+			dst.PathEnd.UpdateClient(hs[scid], dst.MustGetAddress()),
+			dst.PathEnd.ChanTry(src.PathEnd, chans[scid], dst.MustGetAddress()),
 		)
 
 	// Handshake has started on src (2 steps done), relay `chanOpenAck` and `updateClient` to dst
-	case srcEnd.Channel.State == chanState.TRYOPEN && dstEnd.Channel.State == chanState.INIT:
+	case chans[scid].Channel.State == chanState.TRYOPEN && chans[dcid].Channel.State == chanState.INIT:
 		out.Dst = append(out.Dst,
-			dst.PathEnd.UpdateClient(hs[src.ChainID], dst.MustGetAddress()),
-			dst.PathEnd.ChanAck(srcEnd, dst.MustGetAddress()),
+			dst.PathEnd.UpdateClient(hs[scid], dst.MustGetAddress()),
+			dst.PathEnd.ChanAck(chans[scid], dst.MustGetAddress()),
 		)
 
 	// Handshake has started on dst (2 steps done), relay `chanOpenAck` and `updateClient` to src
-	case srcEnd.Channel.State == chanState.INIT && dstEnd.Channel.State == chanState.TRYOPEN:
+	case chans[scid].Channel.State == chanState.INIT && chans[dcid].Channel.State == chanState.TRYOPEN:
 		out.Src = append(out.Src,
-			src.PathEnd.UpdateClient(hs[dst.ChainID], src.MustGetAddress()),
-			src.PathEnd.ChanAck(dstEnd, src.MustGetAddress()),
+			src.PathEnd.UpdateClient(hs[dcid], src.MustGetAddress()),
+			src.PathEnd.ChanAck(chans[dcid], src.MustGetAddress()),
 		)
 
 	// Handshake has confirmed on dst (3 steps done), relay `chanOpenConfirm` and `updateClient` to src
-	case srcEnd.Channel.State == chanState.TRYOPEN && dstEnd.Channel.State == chanState.OPEN:
+	case chans[scid].Channel.State == chanState.TRYOPEN && chans[dcid].Channel.State == chanState.OPEN:
 		out.Src = append(out.Src,
-			src.PathEnd.UpdateClient(hs[dst.ChainID], src.MustGetAddress()),
-			src.PathEnd.ChanConfirm(dstEnd, src.MustGetAddress()),
+			src.PathEnd.UpdateClient(hs[dcid], src.MustGetAddress()),
+			src.PathEnd.ChanConfirm(chans[dcid], src.MustGetAddress()),
 		)
 
 	// Handshake has confirmed on src (3 steps done), relay `chanOpenConfirm` and `updateClient` to dst
-	case srcEnd.Channel.State == chanState.OPEN && dstEnd.Channel.State == chanState.TRYOPEN:
+	case chans[scid].Channel.State == chanState.OPEN && chans[dcid].Channel.State == chanState.TRYOPEN:
 		out.Dst = append(out.Dst,
-			dst.PathEnd.UpdateClient(hs[src.ChainID], dst.MustGetAddress()),
-			dst.PathEnd.ChanConfirm(srcEnd, dst.MustGetAddress()),
+			dst.PathEnd.UpdateClient(hs[scid], dst.MustGetAddress()),
+			dst.PathEnd.ChanConfirm(chans[scid], dst.MustGetAddress()),
 		)
 	}
 

--- a/relayer/tx.go
+++ b/relayer/tx.go
@@ -8,7 +8,6 @@ import (
 	connState "github.com/cosmos/cosmos-sdk/x/ibc/03-connection/exported"
 	chanState "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/exported"
 	commitmentypes "github.com/cosmos/cosmos-sdk/x/ibc/23-commitment/types"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -19,7 +18,7 @@ var (
 )
 
 // CreateClients creates clients for src on dst and dst on src given the configured paths
-func (src *Chain) CreateClients(dst *Chain, cmd *cobra.Command) (err error) {
+func (src *Chain) CreateClients(dst *Chain) (err error) {
 	clients := &RelayMsgs{Src: []sdk.Msg{}, Dst: []sdk.Msg{}}
 
 	// Create client for dst on src if it doesn't exist
@@ -48,7 +47,7 @@ func (src *Chain) CreateClients(dst *Chain, cmd *cobra.Command) (err error) {
 	// TODO: maybe log something here that the client has been created?
 
 	// Send msgs to both chains
-	if err = clients.Send(src, dst, cmd); err != nil {
+	if err = clients.Send(src, dst); err != nil {
 		return err
 	}
 
@@ -57,7 +56,7 @@ func (src *Chain) CreateClients(dst *Chain, cmd *cobra.Command) (err error) {
 
 // CreateConnection runs the connection creation messages on timeout until they pass
 // TODO: add max retries or something to this function
-func (src *Chain) CreateConnection(dst *Chain, to time.Duration, cmd *cobra.Command) error {
+func (src *Chain) CreateConnection(dst *Chain, to time.Duration) error {
 	ticker := time.NewTicker(to)
 	for ; true; <-ticker.C {
 		connSteps, err := src.CreateConnectionStep(dst)
@@ -69,7 +68,7 @@ func (src *Chain) CreateConnection(dst *Chain, to time.Duration, cmd *cobra.Comm
 			break
 		}
 
-		if err = connSteps.Send(src, dst, cmd); err != nil {
+		if err = connSteps.Send(src, dst); err != nil {
 			return err
 		}
 	}
@@ -176,7 +175,7 @@ func (src *Chain) CreateConnectionStep(dst *Chain) (*RelayMsgs, error) {
 
 // CreateChannel runs the channel creation messages on timeout until they pass
 // TODO: add max retries or something to this function
-func (src *Chain) CreateChannel(dst *Chain, ordered bool, to time.Duration, cmd *cobra.Command) error {
+func (src *Chain) CreateChannel(dst *Chain, ordered bool, to time.Duration) error {
 	var order chanState.Order
 	if ordered {
 		order = chanState.ORDERED
@@ -195,7 +194,7 @@ func (src *Chain) CreateChannel(dst *Chain, ordered bool, to time.Duration, cmd 
 			break
 		}
 
-		if err = chanSteps.Send(src, dst, cmd); err != nil {
+		if err = chanSteps.Send(src, dst); err != nil {
 			return err
 		}
 	}

--- a/relayer/verifier.go
+++ b/relayer/verifier.go
@@ -119,7 +119,7 @@ func (c *Chain) InitLiteClientWithoutTrust(db *dbm.GoLevelDB) (*lite.Client, err
 	}
 
 	// TODO: provide actual witnesses!
-	lc, err := lite.NewClientFromTrustedStore(c.ChainID, c.getTrustingPeriod(), httpProvider,
+	lc, err := lite.NewClientFromTrustedStore(c.ChainID, c.GetTrustingPeriod(), httpProvider,
 		[]litep.Provider{httpProvider}, dbs.New(db, ""),
 		lite.Logger(log.NewTMLogger(log.NewSyncWriter(ioutil.Discard))))
 	if err != nil {
@@ -204,7 +204,7 @@ func (c *Chain) DeleteLiteDB() error {
 // TrustOptions returns lite.TrustOptions given a height and hash
 func (c *Chain) TrustOptions(height int64, hash []byte) lite.TrustOptions {
 	return lite.TrustOptions{
-		Period: c.getTrustingPeriod(),
+		Period: c.GetTrustingPeriod(),
 		Height: height,
 		Hash:   hash,
 	}

--- a/relayer/verifier.go
+++ b/relayer/verifier.go
@@ -314,7 +314,7 @@ func GetLatestHeights(chains ...*Chain) (map[string]int64, error) {
 		}(hs, &wg, chain)
 	}
 	wg.Wait()
-	return hs.Map, hs.err()
+	return hs.Map, hs.Errs.err()
 }
 
 // GetLiteSignedHeaderAtHeight returns a signed header at a particular height.

--- a/two-chains.sh
+++ b/two-chains.sh
@@ -75,23 +75,39 @@ echo -e "\n" | gaiad testnet -o $chainid1 --v 1 --chain-id $chainid1 --node-dir-
 
 cfgpth="n0/gaiad/config/config.toml"
 if [ "$(uname)" = "Linux" ]; then
-  # TODO: Just index some specified tags
+  # TODO: Just index *some* specified tags, not all
   # sed -i 's/index_keys = ""/index_keys = "tx.height,tx.hash"'
+  
+  # Set proper defaults and change ports
   sed -i 's/"leveldb"/"goleveldb"/g' $chainid0/$cfgpth
   sed -i 's/"leveldb"/"goleveldb"/g' $chainid1/$cfgpth
   sed -i 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:26556"#g' $chainid1/$cfgpth
   sed -i 's#"tcp://0.0.0.0:26657"#"tcp://0.0.0.0:26557"#g' $chainid1/$cfgpth
   sed -i 's#"localhost:6060"#"localhost:6061"#g' $chainid1/$cfgpth
   sed -i 's#"tcp://127.0.0.1:26658"#"tcp://127.0.0.1:26558"#g' $chainid1/$cfgpth
+  
+  # Make blocks run faster than normal
+  sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid0/$cfgpth
+  sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid1/$cfgpth
+  sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid0/$cfgpth
+  sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid1/$cfgpth
 else
-  # TODO: Just index some specified tags
+  # TODO: Just index *some* specified tags, not all
   # sed -i 's/index_keys = ""/index_keys = "tx.height,tx.hash"'
+
+  # Set proper defaults and change ports
   sed -i '' 's/"leveldb"/"goleveldb"/g' $chainid0/$cfgpth
   sed -i '' 's/"leveldb"/"goleveldb"/g' $chainid1/$cfgpth
   sed -i '' 's#"tcp://0.0.0.0:26656"#"tcp://0.0.0.0:26556"#g' $chainid1/$cfgpth
   sed -i '' 's#"tcp://0.0.0.0:26657"#"tcp://0.0.0.0:26557"#g' $chainid1/$cfgpth
   sed -i '' 's#"localhost:6060"#"localhost:6061"#g' $chainid1/$cfgpth
   sed -i '' 's#"tcp://127.0.0.1:26658"#"tcp://127.0.0.1:26558"#g' $chainid1/$cfgpth
+
+  # Make blocks run faster than normal
+  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid0/$cfgpth
+  sed -i '' 's/timeout_commit = "5s"/timeout_commit = "1s"/g' $chainid1/$cfgpth
+  sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid0/$cfgpth
+  sed -i '' 's/timeout_propose = "3s"/timeout_propose = "1s"/g' $chainid1/$cfgpth
 fi
 
 gclpth="n0/gaiacli/"


### PR DESCRIPTION
This PR continues the work from #59 which started work on #48, closed #31, laid the groundwork for #35.

This PR aims to address #62, #47 and #54. This PR will also remove the `text` output option and introduce a `-d --debug` flag.