### PR TITLE
Add chains url

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -148,7 +148,7 @@ func chainsAddCmd() *cobra.Command {
 		},
 	}
 
-	return fileFlag(cmd)
+	return chainsAddFlags(cmd)
 }
 
 func fileInputAdd(file string) (cfg *Config, err error) {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/cosmos/relayer/relayer"
@@ -122,19 +125,25 @@ func chainsListCmd() *cobra.Command {
 func chainsAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add",
-		Short: "add chains to the configuration file either via user input, or by passing the -f {chain/file.json}",
+		Short: "Add a new chain to the configuration file by passing a file (-f) or url (-u), or user input",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var out *Config
-			file, err := cmd.Flags().GetString(flagFile)
+
+			file, url, err := getAddInputs(cmd)
 			if err != nil {
 				return err
 			}
 
-			if file != "" {
+			switch {
+			case file != "":
 				if out, err = fileInputAdd(file); err != nil {
 					return err
 				}
-			} else {
+			case url != "":
+				if out, err = urlInputAdd(url); err != nil {
+					return err
+				}
+			default:
 				if out, err = userInputAdd(cmd); err != nil {
 					return err
 				}
@@ -257,4 +266,28 @@ func userInputAdd(cmd *cobra.Command) (cfg *Config, err error) {
 	}
 
 	return out, nil
+}
+
+// urlInputAdd validates a chain config URL and fetches its contents
+func urlInputAdd(rawurl string) (cfg *Config, err error) {
+	u, err := url.Parse(rawurl)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return cfg, errors.New("Invalid URL")
+	}
+
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	var c relayer.Chain
+	d := json.NewDecoder(resp.Body)
+	d.DisallowUnknownFields()
+	err = d.Decode(&c)
+	if err != nil {
+		return cfg, err
+	}
+
+	return config.AddChain(&c)
 }

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -29,4 +29,7 @@ func errKeyDoesntExist(name string) error {
 	return fmt.Errorf("a key with name %s doesn't exist", name)
 }
 
-var errInitWrongFlags = errors.New("expected either (--hash/-x & --height) OR --url/-u OR --force/-f, none given")
+var (
+	errInitWrongFlags   = errors.New("expected either (--hash/-x & --height) OR --url/-u OR --force/-f, none given")
+	errMultipleAddFlags = errors.New("expected either --file/-f OR --url/u, found multiple")
+)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -106,5 +106,9 @@ func getAddInputs(cmd *cobra.Command) (file string, url string, err error) {
 		return
 	}
 
-	return file, url, nil
+	if file != "" && url != "" {
+		return "", "", errMultipleAddFlags
+	}
+
+	return
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -49,6 +49,12 @@ func outputFlags(cmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
+func chainsAddFlags(cmd *cobra.Command) *cobra.Command {
+	fileFlag(cmd)
+	urlFlag(cmd)
+	return cmd
+}
+
 func addressFlag(cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().BoolP(flagAddress, "a", false, "returns just the address of the flag, useful for scripting")
 	viper.BindPFlag(flagAddress, cmd.Flags().Lookup(flagAddress))

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -85,7 +85,7 @@ func getTimeout(cmd *cobra.Command) (out time.Duration, err error) {
 }
 
 func urlFlag(cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().StringP(flagURL, "u", "", "url to fecth data from")
+	cmd.Flags().StringP(flagURL, "u", "", "url to fetch data from")
 	viper.BindPFlag(flagURL, cmd.Flags().Lookup(flagURL))
 	return cmd
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	rpcclient "github.com/tendermint/tendermint/rpc/client"
 )
 
 var (
@@ -96,14 +95,16 @@ func urlFlag(cmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
-func getURL(cmd *cobra.Command) (out string, err error) {
-	if out, err = cmd.Flags().GetString(flagURL); err != nil {
+func getAddInputs(cmd *cobra.Command) (file string, url string, err error) {
+	file, err = cmd.Flags().GetString(flagFile)
+	if err != nil {
 		return
 	}
-	if len(out) > 0 {
-		if _, err = rpcclient.NewHTTP(out, "/websocket"); err != nil {
-			return
-		}
+
+	url, err = cmd.Flags().GetString(flagURL)
+	if err != nil {
+		return
 	}
-	return
+
+	return file, url, nil
 }


### PR DESCRIPTION
Addresses [issue #51](https://github.com/cosmos/relayer/issues/51).

## Changes
- Enable adding a chain config from a URL

## Test
```
# First initialize your configuration for the relayer
$ relayer config init

# Then add a chain config by specifying its URL (using ibc0 chain's config from the demo)
$ relayer chains add -u https://raw.githubusercontent.com/cosmos/relayer/master/demo/ibc0.json
```

From https://gist.github.com/kphed/0b4bebcbdedbdb747d84cf18a7280795.