### PR TITLE
Specify args when adding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ interested in building their own relayer can come for working examples.
 While the relayer is under active development, it is meant primarily as a learning tool to better understand the Inter-Blockchain Communication (IBC) protocol. In that vein, the following demo demonstrates the core functionality which will remain even after the changes:
 
 ```bash
-# two-chainz creates two gaia-based chains with data directories in this 
+# two-chainz creates two gaia-based chains with data directories in this
 $ ./two-chainz
 
 # First initialize your configuration for the relayer
@@ -20,7 +20,7 @@ $ relayer config init
 # what is added in each step. The config is located at ~/.relayer/config/config.yaml
 $ cat ~/.relayer/config/config.yaml
 
-# Then add the chains and paths that you will need to work with the 
+# Then add the chains and paths that you will need to work with the
 # gaia chains spun up by the two-chains script
 $ relayer chains add -f demo/ibc0.json
 $ relayer chains add -f demo/ibc1.json
@@ -28,7 +28,7 @@ $ relayer chains add -f demo/ibc1.json
 $ cat ~/.relayer/config/config.yaml
 
 # To finalize your config, add a path between the two chains
-$ relayer paths add -f demo/path.json
+$ relayer paths add ibc0 ibc1 path0 -f demo/path.json
 
 # Now, add the key seeds from each chain to the relayer to give it funds to work with
 $ relayer keys restore ibc0 testkey "$(jq -r '.secret' data/ibc0/n0/gaiacli/key_seed.json)" -a
@@ -39,7 +39,7 @@ $ relayer keys restore ibc1 testkey "$(jq -r '.secret' data/ibc1/n0/gaiacli/key_
 $ relayer lite init ibc0 -f
 $ relayer lite init ibc1 -f
 
-# At this point the relayer --home directory is ready for normal operations between 
+# At this point the relayer --home directory is ready for normal operations between
 # ibc0 and ibc1. Looking at the folder structure of the relayer at this point is helpful
 $ tree ~/.relayer
 
@@ -82,6 +82,6 @@ $ relayer q balance ibc1
 Working with the relayer can frequently involve working with local developement branches of `gaia`, `cosmos-sdk` and the `relayer`. To setup your environment to point at the local versions of the code and reduce the amount of time in your read-eval-print loops try the following:
 
 1. Set `replace github.com/cosmos/cosmos-sdk => /path/to/local/github.com/comsos/cosmos-sdk` at the end of the `go.mod` files for the `relayer` and `gaia`. This will force building from the local version of the `cosmos-sdk` when running the `./dev-env` script.
-2. After `./dev-env` has run, you can use `go run main.go` for any relayer commands you are working on. This allows you make changes and immediately test them as long as there are no server side changes. 
+2. After `./dev-env` has run, you can use `go run main.go` for any relayer commands you are working on. This allows you make changes and immediately test them as long as there are no server side changes.
 3. If you make changes in `cosmos-sdk` that need to be reflected server-side, be sure to re-run `./two-chainz`.
-4. If you need to work off of a `gaia` branch other than `ibc-alpha`, change the branch name at the top of the `./two-chainz` script. 
+4. If you need to work off of a `gaia` branch other than `ibc-alpha`, change the branch name at the top of the `./two-chainz` script.


### PR DESCRIPTION
Following the guide, at line 31
```
relayer paths add -f demo/path.json
```

gives error 
```
Error: accepts 3 arg(s), received 0
```

Added the required args:
```
relayer paths add ibc0 ibc1 path0 -f demo/path.json
```
