### PR TITLE
Fix to set commands to output flags

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -603,12 +603,12 @@ func queryPacketAck() *cobra.Command {
 }
 
 func queryOutput(res interface{}, chain *relayer.Chain, cmd *cobra.Command) error {
-	text, err := cmd.Flags().GetBool("text")
+	text, err := cmd.Flags().GetBool(flagText)
 	if err != nil {
 		panic(err)
 	}
 
-	indent, err := cmd.Flags().GetBool("indent")
+	indent, err := cmd.Flags().GetBool(flags.FlagIndentResponse)
 	if err != nil {
 		panic(err)
 	}
@@ -617,12 +617,12 @@ func queryOutput(res interface{}, chain *relayer.Chain, cmd *cobra.Command) erro
 
 func getPrintingFlags(cmd *cobra.Command) (text, indent bool) {
 	var err error
-	text, err = cmd.Flags().GetBool("text")
+	text, err = cmd.Flags().GetBool(flagText)
 	if err != nil {
 		panic(err)
 	}
 
-	indent, err = cmd.Flags().GetBool("indent")
+	indent, err = cmd.Flags().GetBool(flags.FlagIndentResponse)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/raw.go
+++ b/cmd/raw.go
@@ -69,7 +69,7 @@ func updateClientCmd() *cobra.Command {
 			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.UpdateClient(dstHeader, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func createClientCmd() *cobra.Command {
@@ -98,7 +98,7 @@ func createClientCmd() *cobra.Command {
 		},
 	}
 
-	return cmd
+	return outputFlags(cmd)
 }
 
 func connInit() *cobra.Command {
@@ -124,7 +124,7 @@ func connInit() *cobra.Command {
 			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.ConnInit(chains[dst].PathEnd, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func connTry() *cobra.Command {
@@ -180,7 +180,7 @@ func connTry() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func connAck() *cobra.Command {
@@ -236,7 +236,7 @@ func connAck() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func connConfirm() *cobra.Command {
@@ -279,7 +279,7 @@ func connConfirm() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func createConnectionStepCmd() *cobra.Command {
@@ -323,7 +323,7 @@ func createConnectionStepCmd() *cobra.Command {
 		},
 	}
 
-	return cmd
+	return outputFlags(cmd)
 }
 
 func chanInit() *cobra.Command {
@@ -354,7 +354,7 @@ func chanInit() *cobra.Command {
 			return sendAndPrint([]sdk.Msg{chains[src].PathEnd.ChanInit(chains[dst].PathEnd, order, chains[src].MustGetAddress())}, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func chanTry() *cobra.Command {
@@ -395,7 +395,7 @@ func chanTry() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func chanAck() *cobra.Command {
@@ -436,7 +436,7 @@ func chanAck() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func chanConfirm() *cobra.Command {
@@ -477,7 +477,7 @@ func chanConfirm() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func createChannelStepCmd() *cobra.Command {
@@ -521,7 +521,7 @@ func createChannelStepCmd() *cobra.Command {
 		},
 	}
 
-	return cmd
+	return outputFlags(cmd)
 }
 
 func chanCloseInit() *cobra.Command {
@@ -542,7 +542,7 @@ func chanCloseInit() *cobra.Command {
 			return sendAndPrint([]sdk.Msg{src.PathEnd.ChanCloseInit(src.MustGetAddress())}, src, cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func chanCloseConfirm() *cobra.Command {
@@ -583,7 +583,7 @@ func chanCloseConfirm() *cobra.Command {
 			return sendAndPrint(txs, chains[src], cmd)
 		},
 	}
-	return cmd
+	return outputFlags(cmd)
 }
 
 func sendAndPrint(txs []sdk.Msg, c *relayer.Chain, cmd *cobra.Command) error {


### PR DESCRIPTION
Hi, there.

`sendAndPrint` function needs the "text" and "indent" flags, but these are not given to `raw` commands, so panic is currently occurring at runtime.

Here's the error log:
```
$ rly --home ./.relayer transactions raw update-client ibc1 ibc0 ibconeclient

panic: flag accessed but not defined: text

goroutine 1 [running]:
github.com/iqlusioninc/relayer/cmd.getPrintingFlags(0xc000ca3b80, 0xc000b7bba0)
        /home/jun/src/relayer/cmd/query.go:622 +0xf3
github.com/iqlusioninc/relayer/cmd.sendAndPrint(0xc000206bd0, 0x1, 0x1, 0xc000cdc900, 0xc000ca3b80, 0x0, 0xc000ceaae0)
        /home/jun/src/relayer/cmd/raw.go:590 +0x2b
github.com/iqlusioninc/relayer/cmd.updateClientCmd.func1(0xc000ca3b80, 0xc000cb68c0, 0x3, 0x5, 0x0, 0x0)
        /home/jun/src/relayer/cmd/raw.go:69 +0x587
github.com/spf13/cobra.(*Command).execute(0xc000ca3b80, 0xc000cb6870, 0x5, 0x5, 0xc000ca3b80, 0xc000cb6870)
        /home/jun/go/1.13.5/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:840 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0x1f67620, 0x43f13a, 0x1efc600, 0xc000000180)
        /home/jun/go/1.13.5/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:945 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
        /home/jun/go/1.13.5/pkg/mod/github.com/spf13/cobra@v0.0.6/command.go:885
github.com/iqlusioninc/relayer/cmd.Execute()
        /home/jun/src/relayer/cmd/root.go:97 +0x55
main.main()
        /home/jun/src/relayer/main.go:21 +0x20
```